### PR TITLE
pull request for issue #67 - The behavior is expected and it is by design. I enhanced the reinderer by

### DIFF
--- a/renderer/src/main/java/armyc2/c2sd/JavaTacticalRenderer/Modifier2.java
+++ b/renderer/src/main/java/armyc2/c2sd/JavaTacticalRenderer/Modifier2.java
@@ -1561,36 +1561,80 @@ public class Modifier2 {
                 return;
             }
 
-            int stringWidth = metrics.stringWidth(label);
+            int stringWidth = metrics.stringWidth(label); 
             boolean foundLongSegment = false;
             double dist = 0;
             POINT2 pt0 = null, pt1 = null;
             int n = tg.Pixels.size();
-            //for (j = startIndex; j < tg.Pixels.size() - 1; j++) 
-            for (j = startIndex; j < n - 1; j++) {
-                pt0 = tg.Pixels.get(j);
-                pt1 = tg.Pixels.get(j + 1);
-                dist = lineutility.CalcDistanceDouble(pt0, pt1);
-                if (dist > 1.5 * stringWidth) {
-                    foundLongSegment = true;
-                    AddIntegralAreaModifier(tg, label, aboveMiddle, 0, pt0, pt1, true);
-                }
+            
+            int northestPtIndex = 0;
+    		int southestPtIndex = 0;
+    		POINT2 northestPt = null;
+    		POINT2 southestPt = null;
+    		
+    		//acevedo - 11/6/2017 - adding option to render only 2 ENY labels.
+            if (armyc2.c2sd.renderer.utilities.RendererSettings.getInstance().getTwoENYLabelOnly() == false) {
+            
+	            //for (j = startIndex; j < tg.Pixels.size() - 1; j++) 
+	            for (j = startIndex; j < n - 1; j++) {
+	                pt0 = tg.Pixels.get(j);
+	                pt1 = tg.Pixels.get(j + 1);
+	                dist = lineutility.CalcDistanceDouble(pt0, pt1);
+	                if (dist > 1.5 * stringWidth) {
+	                    foundLongSegment = true;
+	                    AddIntegralAreaModifier(tg, label, aboveMiddle, 0, pt0, pt1, true);
+	                }
+	            }
+	            if (foundLongSegment == false)//we did not find a long enough segment
+	            {
+	                if (middleSegment != startIndex) {
+	                    AddIntegralModifier(tg, label, aboveMiddle, 0, middleSegment, middleSegment + 1, true);
+	                }
+	                AddIntegralModifier(tg, label, aboveMiddle, 0, middleSegment2, middleSegment2 + 1, true);
+	
+	            }
             }
-            if (foundLongSegment == false)//we did not find a long enough segment
-            {
-                if (middleSegment != startIndex) {
-                    AddIntegralModifier(tg, label, aboveMiddle, 0, middleSegment, middleSegment + 1, true);
-                }
+            else {
+                // 2 ENY labels one to the north and the other to the south of graphic.
+                for (j = startIndex; j < n - 1; j++) {
+                    pt0 = tg.Pixels.get(j);
 
+        			if (northestPt == null)
+        			{
+        				northestPt = pt0;
+        				northestPtIndex = j;
+        			}
+        			if (southestPt == null)
+        			{
+        				southestPt = pt0;
+        				southestPtIndex = j;
+        			}
+        			if (pt0.y >= northestPt.y)
+        			{
+        				northestPt = pt0;
+        				northestPtIndex = j;
+        			}
+
+        			if (pt0.y <= southestPt.y)
+        			{
+        				southestPt = pt0;
+        				southestPtIndex = j;
+        			}
+                }//for
+
+        		middleSegment = northestPtIndex;
+        		middleSegment2 = southestPtIndex;
+                if (middleSegment != startIndex)
+                	AddIntegralModifier(tg, label, aboveMiddle, 0, middleSegment, middleSegment + 1, true);
                 AddIntegralModifier(tg, label, aboveMiddle, 0, middleSegment2, middleSegment2 + 1, true);
-
-            }
+            }//else
         } catch (Exception exc) {
             ErrorLogger.LogException(_className, "areasWithENY",
                     new RendererException("Failed inside areasWithENY", exc));
         }
     }
-
+  
+    
     private static int getVisibleMiddleSegment(TGLight tg, Rectangle2D clipBounds) {
         int middleSegment = -1;
         try {

--- a/renderer/src/main/java/armyc2/c2sd/renderer/utilities/RendererSettings.java
+++ b/renderer/src/main/java/armyc2/c2sd/renderer/utilities/RendererSettings.java
@@ -155,6 +155,9 @@ public class RendererSettings{
     
     private static int _CacheSize = 1024;
     private static int _VMSize = 10240;
+    
+    //acevedo - 11/6/2017 - adding option to render only 2 ENY labels.
+    private boolean _TwoENYLabelOnly = true;
 
     private RendererSettings()
     {
@@ -777,4 +780,25 @@ public class RendererSettings{
     {
         return _CacheSize;
     }
+    
+    /**
+  	 ** Get a boolean indicating between the use of ENY labels in all segments (false) or 
+ 	 * to only set 2 labels one at the north and the other one at the south of the graphic (true).
+  	 * @returns {boolean}
+  	 */
+  	public boolean getTwoENYLabelOnly()
+  	{
+  			return _TwoENYLabelOnly;
+  	}
+  	
+  	/**
+ 	 * Set a boolean indicating between the use of ENY labels in all segments (false) or 
+ 	 * to only set 2 labels one at the north and the other one at the south of the graphic (true).
+ 	 * @param TwoENYLabelOnly
+ 	 */
+ 	public boolean setTwoENYLabelOnly(boolean TwoENYLabelOnly )
+ 	{
+ 		_TwoENYLabelOnly = TwoENYLabelOnly;
+ 	}
+ 	
 }

--- a/renderer/src/main/java/armyc2/c2sd/renderer/utilities/RendererSettings.java
+++ b/renderer/src/main/java/armyc2/c2sd/renderer/utilities/RendererSettings.java
@@ -796,7 +796,7 @@ public class RendererSettings{
  	 * to only set 2 labels one at the north and the other one at the south of the graphic (true).
  	 * @param TwoENYLabelOnly
  	 */
- 	public boolean setTwoENYLabelOnly(boolean TwoENYLabelOnly )
+ 	public void setTwoENYLabelOnly(boolean TwoENYLabelOnly )
  	{
  		_TwoENYLabelOnly = TwoENYLabelOnly;
  	}


### PR DESCRIPTION
adding an option to display ENY labels in all segments, or to only
display the label 2 times, one in the north and the other one in the
south of the hostile graphics that display ENY.