### PR TITLE
Fix strict mode warning

### DIFF
--- a/renderer/src/main/java/armyc2/c2sd/renderer/utilities/FontManager.java
+++ b/renderer/src/main/java/armyc2/c2sd/renderer/utilities/FontManager.java
@@ -194,9 +194,28 @@ public class FontManager {
 			if(exc != null)
 				ErrorLogger.LogException("SPR", "getFont", exc);
 		}
+		finally
+		{
+			silentClose(is);
+		}
 		return tf;
 	}//*/
-	
+
+	private void silentClose(InputStream is){
+		if(is == null)
+		{
+			return;
+		}
+		try
+		{
+			is.close();
+		}
+		catch (IOException ignore)
+		{
+			// Ignore
+		}
+	}
+
 	public void testFontFiles()
 	{
 		Paint fillPaint = new Paint();


### PR DESCRIPTION
Close the input stream in the FontManager so we no longer get a strict mode warning