### PR TITLE
Fix an unecessary error message that was caused when a Metoc graphic is off screen and a bbox value is passed in.

### DIFF
--- a/renderer/src/main/java/sec/web/render/SECWebRenderer.java
+++ b/renderer/src/main/java/sec/web/render/SECWebRenderer.java
@@ -805,20 +805,23 @@ public final class SECWebRenderer /* extends Applet */ {
                 int size = RendererSettings.getInstance().getDefaultPixelSize();
 
                 ArrayList<ShapeInfo> shapes = mSymbol.getSymbolShapes();
-                //ShapeInfo shape = shapes.get(shapes.size());
-                ShapeInfo shape = shapes.get(0);
-                shape.setPatternFillImage(PatternFillRenderer.MakeSymbolPatternFill(A,size));
-                if(shape.getPatternFillImage() != null)
-                    shape.setShader(new BitmapShader(shape.getPatternFillImage(), Shader.TileMode.REPEAT, Shader.TileMode.REPEAT));
+                if(shapes.size() > 0){
+                    ShapeInfo shape = shapes.get(0);
+                    shape.setPatternFillImage(PatternFillRenderer.MakeSymbolPatternFill(A,size));
+                    if(shape.getPatternFillImage() != null)
+                        shape.setShader(new BitmapShader(shape.getPatternFillImage(), Shader.TileMode.REPEAT, Shader.TileMode.REPEAT));
+                }
             }
             else if(basicID.charAt(0) == 'W')
             {
                 ArrayList<ShapeInfo> shapes = mSymbol.getSymbolShapes();
-                //ShapeInfo shape = shapes.get(shapes.size());
-                ShapeInfo shape = shapes.get(0);
-                shape.setPatternFillImage(PatternFillRenderer.MakeMetocPatternFill(symbolCode));
-                if(shape.getPatternFillImage() != null)
-                    shape.setShader(new BitmapShader(shape.getPatternFillImage(), Shader.TileMode.REPEAT, Shader.TileMode.REPEAT));
+                if(shapes.size() > 0)
+                {
+                    ShapeInfo shape = shapes.get(0);
+                    shape.setPatternFillImage(PatternFillRenderer.MakeMetocPatternFill(symbolCode));
+                    if(shape.getPatternFillImage() != null)
+                        shape.setShader(new BitmapShader(shape.getPatternFillImage(), Shader.TileMode.REPEAT, Shader.TileMode.REPEAT));
+                }
             }
 
 		}


### PR DESCRIPTION
If the graphic is off screen sometimes the shapes list that is returned can be empty. This can be a problem because we assume when drawing METOC graphics that the shapes list is not empty, causing an exception and unnecessary log message.  