### PR TITLE
Changed the way we handled units of measure

### DIFF
--- a/renderer/src/main/java/armyc2/c2sd/JavaRendererServer/RenderMultipoints/clsRenderer.java
+++ b/renderer/src/main/java/armyc2/c2sd/JavaRendererServer/RenderMultipoints/clsRenderer.java
@@ -237,9 +237,9 @@ public final class clsRenderer {
             if (altitudeLabel == null || altitudeLabel.isEmpty()) {
                 altitudeLabel = "MSL";
             }
-            String altitudeUnit = milStd.getAltitudeUnit();
+            DistanceUnit altitudeUnit = milStd.getAltitudeUnit();
             if(altitudeUnit == null){
-                altitudeUnit = "ft.";
+                altitudeUnit = DistanceUnit.FEET;
             }
             DistanceUnit distanceUnit = milStd.getDistanceUnit();
             if(distanceUnit == null){
@@ -823,8 +823,15 @@ public final class clsRenderer {
         return tg;
     }
 
-    private static String createAltitudeLabel(double distance, String altitudeUnit, String altitudeLabel){
-        return distance + " " + altitudeUnit + " " + altitudeLabel;
+    private static String createAltitudeLabel(double distance, DistanceUnit altitudeUnit, String altitudeLabel){
+        // Truncate the result
+        double result = distance * altitudeUnit.conversionFactor;
+        result *= 10.0;
+        result = Math.round(result);
+        int tempResult = (int) result;
+        result = tempResult / 10.0;
+
+        return result + " " + altitudeUnit.label + " " + altitudeLabel;
     }
 
     /**

--- a/renderer/src/main/java/armyc2/c2sd/JavaRendererServer/RenderMultipoints/clsRenderer.java
+++ b/renderer/src/main/java/armyc2/c2sd/JavaRendererServer/RenderMultipoints/clsRenderer.java
@@ -3,33 +3,22 @@
  */
 package armyc2.c2sd.JavaRendererServer.RenderMultipoints;
 
-import armyc2.c2sd.renderer.utilities.IPointConversion;
-import armyc2.c2sd.renderer.utilities.ShapeInfo;
-import armyc2.c2sd.renderer.utilities.MilStdSymbol;
-import armyc2.c2sd.renderer.utilities.ErrorLogger;
-import armyc2.c2sd.renderer.utilities.RendererException;
-import armyc2.c2sd.renderer.utilities.ModifiersTG;
-import armyc2.c2sd.JavaLineArray.arraysupport;
+import armyc2.c2sd.renderer.utilities.*;
 import armyc2.c2sd.JavaLineArray.CELineArray;
-import armyc2.c2sd.JavaLineArray.Channels;
 import armyc2.c2sd.JavaLineArray.POINT2;
-import armyc2.c2sd.JavaLineArray.ref;
+
 import java.util.ArrayList;
 import armyc2.c2sd.JavaLineArray.Shape2;
 import armyc2.c2sd.JavaLineArray.TacticalLines;
 import armyc2.c2sd.JavaLineArray.lineutility;
 import armyc2.c2sd.JavaTacticalRenderer.TGLight;
 import armyc2.c2sd.JavaTacticalRenderer.Modifier2;
-import armyc2.c2sd.JavaTacticalRenderer.clsChannelUtility;
 import armyc2.c2sd.JavaTacticalRenderer.clsMETOC;
-import armyc2.c2sd.JavaTacticalRenderer.P1;
 import armyc2.c2sd.JavaTacticalRenderer.mdlGeodesic;
 //import armyc2.c2sd.JavaTacticalRenderer.clsUtility;
-import armyc2.c2sd.renderer.utilities.Color;
 import armyc2.c2sd.graphics2d.*;
 import android.content.Context;
 import android.util.SparseArray;
-import armyc2.c2sd.renderer.utilities.RendererSettings;
 
 /**
  * Rendering class
@@ -39,7 +28,6 @@ import armyc2.c2sd.renderer.utilities.RendererSettings;
 public final class clsRenderer {
 
     private static final String _className = "clsRenderer";
-    private static double feetPerMeter = 3.28084;
 
     /**
      * Set tg geo points from the client points
@@ -249,6 +237,15 @@ public final class clsRenderer {
             if (altitudeLabel == null || altitudeLabel.isEmpty()) {
                 altitudeLabel = "MSL";
             }
+            String altitudeUnit = milStd.getAltitudeUnit();
+            if(altitudeUnit == null){
+                altitudeUnit = "ft.";
+            }
+            DistanceUnit distanceUnit = milStd.getDistanceUnit();
+            if(distanceUnit == null){
+                distanceUnit = DistanceUnit.METERS;
+            }
+
             double x_alt = 0;
             int n_alt = 0;
             String strXAlt = "";
@@ -350,13 +347,13 @@ public final class clsRenderer {
                     String strH1 = "";
                     for (int j = 0; j < X.size(); j++) {
                         //strH1 += Double.toString(X.get(j));
-                        x_alt = X.get(j) * feetPerMeter;
+                        x_alt = X.get(j);
                         //strXAlt=Double.toString(x_alt)+" ft. "+altitudeLabel;
                         x_alt *= 10.0;
                         x_alt = Math.round(x_alt);
                         n_alt = (int) x_alt;
                         x_alt = n_alt / 10.0;
-                        strXAlt = Double.toString(x_alt) + " ft. " + altitudeLabel;
+                        strXAlt = createAltitudeLabel(x_alt, altitudeUnit, altitudeLabel);
                         strH1 += strXAlt;
 
                         if (j < X.size() - 1) {
@@ -494,24 +491,24 @@ public final class clsRenderer {
                     ArrayList<Double> X = milStd.getModifiers_AM_AN_X(ModifiersTG.X_ALTITUDE_DEPTH);
                     if (X != null && X.size() > 0) {
                         //tg.set_H(Double.toString(X.get(0)));
-                        x_alt = X.get(0) * feetPerMeter;
+                        x_alt = X.get(0);
                         //strXAlt=Double.toString(x_alt)+" ft. "+altitudeLabel;
                         x_alt *= 10.0;
                         x_alt = Math.round(x_alt);
                         n_alt = (int) x_alt;
                         x_alt = n_alt / 10.0;
-                        strXAlt = Double.toString(x_alt) + " ft. " + altitudeLabel;
+                        strXAlt = createAltitudeLabel(x_alt, altitudeUnit, altitudeLabel);
                         tg.set_H(strXAlt);
                     }
                     if (X != null && X.size() > 1) {
                         //tg.set_H1(Double.toString(X.get(1)));
-                        x_alt = X.get(1) * feetPerMeter;
+                        x_alt = X.get(1);
                         //strXAlt=Double.toString(x_alt)+" ft. "+altitudeLabel;
                         x_alt *= 10.0;
                         x_alt = Math.round(x_alt);
                         n_alt = (int) x_alt;
                         x_alt = n_alt / 10.0;
-                        strXAlt = Double.toString(x_alt) + " ft. " + altitudeLabel;
+                        strXAlt = createAltitudeLabel(x_alt, altitudeUnit, altitudeLabel);
                         tg.set_H1(strXAlt);
                     }
                     break;
@@ -600,30 +597,37 @@ public final class clsRenderer {
                             }
                         }
                     }
+
+                    maxWidthMeters *= distanceUnit.conversionFactor;
+                    maxWidthMeters *= 10.0;
+                    maxWidthMeters = Math.round(maxWidthMeters);
+                    int tempWidth = (int) maxWidthMeters;
+                    maxWidthMeters = tempWidth / 10.0;
+
                     //now set tg.H2 to the max value so that the H2 modifier will display as the max vaule;
-                    tg.set_H2(Double.toString(maxWidthMeters) + "m");
+                    tg.set_H2(Double.toString(maxWidthMeters) + " " + distanceUnit.label);
                     //use X, X1 to set tg.H, tg.H1
                     X = milStd.getModifiers_AM_AN_X(ModifiersTG.X_ALTITUDE_DEPTH);
                     if (X != null && X.size() > 0) {
                         //tg.set_H(Double.toString(X.get(0)));
-                        x_alt = X.get(0) * feetPerMeter;
+                        x_alt = X.get(0);
                         //strXAlt=Double.toString(x_alt)+" ft. "+altitudeLabel;
                         x_alt *= 10.0;
                         x_alt = Math.round(x_alt);
                         n_alt = (int) x_alt;
                         x_alt = n_alt / 10.0;
-                        strXAlt = Double.toString(x_alt) + " ft. " + altitudeLabel;
+                        strXAlt = createAltitudeLabel(x_alt, altitudeUnit, altitudeLabel);
                         tg.set_H(strXAlt);
                     }
                     if (X != null && X.size() > 1) {
                         //tg.set_H1(Double.toString(X.get(1)));
-                        x_alt = X.get(1) * feetPerMeter;
+                        x_alt = X.get(1);
                         //strXAlt=Double.toString(x_alt)+" ft. "+altitudeLabel;
                         x_alt *= 10.0;
                         x_alt = Math.round(x_alt);
                         n_alt = (int) x_alt;
                         x_alt = n_alt / 10.0;
-                        strXAlt = Double.toString(x_alt) + " ft. " + altitudeLabel;
+                        strXAlt = createAltitudeLabel(x_alt, altitudeUnit, altitudeLabel);
                         tg.set_H1(strXAlt);
                     }
                     break;
@@ -640,13 +644,13 @@ public final class clsRenderer {
                     if (X != null && !X.isEmpty()) {
                         //strH1 = Double.toString(X.get(0));
                         //tg.set_H1(strH1);
-                        x_alt = X.get(0) * feetPerMeter;
+                        x_alt = X.get(0);
                         //strXAlt=Double.toString(x_alt)+" ft. "+altitudeLabel;
                         x_alt *= 10.0;
                         x_alt = Math.round(x_alt);
                         n_alt = (int) x_alt;
                         x_alt = n_alt / 10.0;
-                        strXAlt = Double.toString(x_alt) + " ft. " + altitudeLabel;
+                        strXAlt = createAltitudeLabel(x_alt, altitudeUnit, altitudeLabel);
                         tg.set_H1(strXAlt);
                     }
                     break;
@@ -668,13 +672,13 @@ public final class clsRenderer {
 
                         if (X != null && j < X.size()) {
                             //strH1 += Double.toString(X.get(j));
-                            x_alt = X.get(j) * feetPerMeter;
+                            x_alt = X.get(j);
                             //strXAlt=Double.toString(x_alt)+" ft. "+altitudeLabel;
                             x_alt *= 10.0;
                             x_alt = Math.round(x_alt);
                             n_alt = (int) x_alt;
                             x_alt = n_alt / 10.0;
-                            strXAlt = Double.toString(x_alt) + " ft. " + altitudeLabel;
+                            strXAlt = createAltitudeLabel(x_alt, altitudeUnit, altitudeLabel);
                             strH1 += strXAlt;
                             if (j < X.size() - 1) {
                                 strH1 += ",";
@@ -817,6 +821,10 @@ public final class clsRenderer {
                     new RendererException("Failed to build multipoint TG for " + milStd.getSymbolID(), exc));
         }
         return tg;
+    }
+
+    private static String createAltitudeLabel(double distance, String altitudeUnit, String altitudeLabel){
+        return distance + " " + altitudeUnit + " " + altitudeLabel;
     }
 
     /**

--- a/renderer/src/main/java/armyc2/c2sd/renderer/utilities/DistanceUnit.java
+++ b/renderer/src/main/java/armyc2/c2sd/renderer/utilities/DistanceUnit.java
@@ -5,6 +5,8 @@ import java.text.DecimalFormat;
 
 public class DistanceUnit
 {
+    private static final double FEET_PER_METER = 3.28084;
+
     public final double conversionFactor;
     public final String label;
 
@@ -32,4 +34,6 @@ public class DistanceUnit
     }
 
     public static DistanceUnit METERS = new DistanceUnit(1, "m.");
+
+    public static DistanceUnit FEET = new DistanceUnit(FEET_PER_METER, "ft.");
 }

--- a/renderer/src/main/java/armyc2/c2sd/renderer/utilities/DistanceUnit.java
+++ b/renderer/src/main/java/armyc2/c2sd/renderer/utilities/DistanceUnit.java
@@ -1,0 +1,35 @@
+package armyc2.c2sd.renderer.utilities;
+
+import java.math.RoundingMode;
+import java.text.DecimalFormat;
+
+public class DistanceUnit
+{
+    public final double conversionFactor;
+    public final String label;
+
+    public DistanceUnit(double conversionFactor, String label){
+        this.conversionFactor = conversionFactor;
+        this.label = label;
+    }
+
+    public static DistanceUnit parse(String distanceUnitText){
+        if(distanceUnitText == null){
+            return null;
+        }
+        String[] parts = distanceUnitText.split(",");
+        if(parts.length != 2){
+            return null;
+        }
+        double conversionFactor = Double.parseDouble(parts[0].trim());
+        String label = parts[1].trim();
+
+        return new DistanceUnit(conversionFactor, label);
+    }
+
+    public String toAttribute(){
+        return conversionFactor + "," + label;
+    }
+
+    public static DistanceUnit METERS = new DistanceUnit(1, "m.");
+}

--- a/renderer/src/main/java/armyc2/c2sd/renderer/utilities/MilStdAttributes.java
+++ b/renderer/src/main/java/armyc2/c2sd/renderer/utilities/MilStdAttributes.java
@@ -99,8 +99,7 @@ public class MilStdAttributes {
     /**
      * The mode that altitude labels will be displayed in, the default value is HAE.
      *
-     * Unlike {@link #DistanceUnits} this attribute does no conversion, this is merely a label. The values
-     * must be converted properly before they are passed in as modifiers
+     * This value acts as a label, appending whatever string that is passed in to the end of the altitude units.
      */
     public static final int AltitudeMode = 16;
 
@@ -123,10 +122,11 @@ public class MilStdAttributes {
     public static final int DistanceUnits = 20;
 
     /**
-     * The units that you want to display altitude values in. The default value is feet.
+     * The conversion factor and the label that you want all distances to display in. The conversion factor
+     * is converting from meters. The default unit is meters.<br><br>
      *
-     * Unlike {@link #DistanceUnits} this attribute does no conversion, this is merely a label. The values
-     * must be converted properly before they are passed in as modifiers
+     * Must be in the form [conversionFactor],[label]. So for example converting to feet would be "3.28,ft."
+     * The helper class {@link DistanceUnit} can be used.
      */
     public static final int AltitudeUnits = 21;
     

--- a/renderer/src/main/java/armyc2/c2sd/renderer/utilities/MilStdAttributes.java
+++ b/renderer/src/main/java/armyc2/c2sd/renderer/utilities/MilStdAttributes.java
@@ -95,7 +95,13 @@ public class MilStdAttributes {
      * DashArray from the Stroke object from the ShapeInfo object.
      */
     public static final int UseDashArray = 15;
-    
+
+    /**
+     * The mode that altitude labels will be displayed in, the default value is HAE.
+     *
+     * Unlike {@link #DistanceUnits} this attribute does no conversion, this is merely a label. The values
+     * must be converted properly before they are passed in as modifiers
+     */
     public static final int AltitudeMode = 16;
 
     /**
@@ -106,6 +112,23 @@ public class MilStdAttributes {
     public static final int UsePatternFill = 18;
 
     public static final int PatternFillType = 19;
+
+    /**
+     * The conversion factor and the label that you want all distances to display in. The conversion factor
+     * is converting from meters. The default unit is meters.<br><br>
+     *
+     * Must be in the form [conversionFactor],[label]. So for example converting to feet would be "3.28,ft."
+     * The helper class {@link DistanceUnit} can be used.
+     */
+    public static final int DistanceUnits = 20;
+
+    /**
+     * The units that you want to display altitude values in. The default value is feet.
+     *
+     * Unlike {@link #DistanceUnits} this attribute does no conversion, this is merely a label. The values
+     * must be converted properly before they are passed in as modifiers
+     */
+    public static final int AltitudeUnits = 21;
     
     public static ArrayList<Integer> GetModifierList()
     {
@@ -125,6 +148,8 @@ public class MilStdAttributes {
         list.add(DrawAsIcon);
         list.add(SymbologyStandard);
         list.add(HideOptionalLabels);
+        list.add(DistanceUnits);
+        list.add(AltitudeUnits);
         
         return list;
     }

--- a/renderer/src/main/java/armyc2/c2sd/renderer/utilities/MilStdSymbol.java
+++ b/renderer/src/main/java/armyc2/c2sd/renderer/utilities/MilStdSymbol.java
@@ -79,7 +79,7 @@ public class MilStdSymbol
     
     private static String _AltitudeMode = "";
 
-    private static String _AltitudeUnit = null;
+    private static DistanceUnit _AltitudeUnit = null;
 
     private static DistanceUnit _DistanceUnit = null;
 
@@ -285,11 +285,11 @@ public class MilStdSymbol
         _AltitudeMode = value;
     }
 
-    public String getAltitudeUnit(){
+    public DistanceUnit getAltitudeUnit(){
         return _AltitudeUnit;
     }
 
-    public void setAltitudeUnit(String unit){
+    public void setAltitudeUnit(DistanceUnit unit){
         _AltitudeUnit = unit;
     }
 

--- a/renderer/src/main/java/armyc2/c2sd/renderer/utilities/MilStdSymbol.java
+++ b/renderer/src/main/java/armyc2/c2sd/renderer/utilities/MilStdSymbol.java
@@ -79,6 +79,10 @@ public class MilStdSymbol
     
     private static String _AltitudeMode = "";
 
+    private static String _AltitudeUnit = null;
+
+    private static DistanceUnit _DistanceUnit = null;
+
     private static boolean _useDashArray = true;
 
     private static boolean _hideOptionalLabels = false;
@@ -279,6 +283,22 @@ public class MilStdSymbol
     public void setAltitudeMode(String value)
     {
         _AltitudeMode = value;
+    }
+
+    public String getAltitudeUnit(){
+        return _AltitudeUnit;
+    }
+
+    public void setAltitudeUnit(String unit){
+        _AltitudeUnit = unit;
+    }
+
+    public DistanceUnit getDistanceUnit(){
+        return _DistanceUnit;
+    }
+
+    public void setDistanceUnit(DistanceUnit unit){
+        _DistanceUnit = unit;
     }
     
     public boolean getUseDashArray()

--- a/renderer/src/main/java/sec/web/render/MultiPointHandler.java
+++ b/renderer/src/main/java/sec/web/render/MultiPointHandler.java
@@ -1868,7 +1868,7 @@ public class MultiPointHandler {
         int patternFillType = 0;
         boolean hideOptionalLabels = false;
         DistanceUnit distanceUnit = null;
-        String altitudeUnit = null;
+        DistanceUnit altitudeUnit = null;
 
         String symbolFillIDs = null;
         String symbolFillIconSize = null;
@@ -2003,7 +2003,7 @@ public class MultiPointHandler {
                 }
 
                 if(saAttributes.indexOfKey(MilStdAttributes.AltitudeUnits) >= 0) {
-                    altitudeUnit = saAttributes.get(MilStdAttributes.AltitudeUnits);
+                    altitudeUnit = DistanceUnit.parse(saAttributes.get(MilStdAttributes.AltitudeUnits));
                 }
 
                 if(saAttributes.indexOfKey(MilStdAttributes.DistanceUnits) >= 0) {

--- a/renderer/src/main/java/sec/web/render/MultiPointHandler.java
+++ b/renderer/src/main/java/sec/web/render/MultiPointHandler.java
@@ -7,20 +7,13 @@ import android.util.SparseArray;
 import armyc2.c2sd.graphics2d.*;
 
 import java.util.Map;
+
+import armyc2.c2sd.renderer.utilities.*;
 import sec.geo.utilities.StringBuilder;
 import sec.web.render.utilities.JavaRendererUtilities;
 import sec.web.render.utilities.LineInfo;
 import sec.web.render.utilities.SymbolInfo;
 import sec.web.render.utilities.TextInfo;
-import armyc2.c2sd.renderer.utilities.IPointConversion;
-import armyc2.c2sd.renderer.utilities.MilStdAttributes;
-import armyc2.c2sd.renderer.utilities.MilStdSymbol;
-import armyc2.c2sd.renderer.utilities.ModifiersTG;
-import armyc2.c2sd.renderer.utilities.PointConversion;
-import armyc2.c2sd.renderer.utilities.RendererSettings;
-import armyc2.c2sd.renderer.utilities.ShapeInfo;
-import armyc2.c2sd.renderer.utilities.Color;
-import armyc2.c2sd.renderer.utilities.SymbolUtilities;
 import armyc2.c2sd.JavaLineArray.POINT2;
 import armyc2.c2sd.JavaLineArray.CELineArray;
 import armyc2.c2sd.JavaLineArray.TacticalLines;
@@ -30,17 +23,11 @@ import armyc2.c2sd.JavaRendererServer.RenderMultipoints.clsClipPolygon2;
 import armyc2.c2sd.JavaTacticalRenderer.mdlGeodesic;
 import java.util.LinkedList;
 import java.util.List;
-import armyc2.c2sd.renderer.utilities.SymbolDef;
-import armyc2.c2sd.renderer.utilities.SymbolDefTable;
-import armyc2.c2sd.renderer.utilities.ErrorLogger;
-import armyc2.c2sd.renderer.utilities.RendererException;
 import java.util.logging.Level;
-import armyc2.c2sd.renderer.MilStdIconRenderer;
 //import java.awt.font.TextAttribute;
 //import java.awt.font.NumericShaper;
 import android.graphics.Typeface;
-import armyc2.c2sd.renderer.utilities.RendererUtilities;
-import armyc2.c2sd.graphics2d.*;
+
 import sec.geo.GeoPoint;
 import sec.geo.kml.KmlOptions;
 import sec.geo.kml.XsltCoordinateWrapper;
@@ -1880,6 +1867,8 @@ public class MultiPointHandler {
         boolean usePatternFill = symbol.getUseFillPattern();
         int patternFillType = 0;
         boolean hideOptionalLabels = false;
+        DistanceUnit distanceUnit = null;
+        String altitudeUnit = null;
 
         String symbolFillIDs = null;
         String symbolFillIconSize = null;
@@ -2012,6 +2001,14 @@ public class MultiPointHandler {
                 if (saAttributes.indexOfKey(MilStdAttributes.HideOptionalLabels) >= 0) {
                     hideOptionalLabels = Boolean.parseBoolean(saAttributes.get(MilStdAttributes.HideOptionalLabels));
                 }
+
+                if(saAttributes.indexOfKey(MilStdAttributes.AltitudeUnits) >= 0) {
+                    altitudeUnit = saAttributes.get(MilStdAttributes.AltitudeUnits);
+                }
+
+                if(saAttributes.indexOfKey(MilStdAttributes.DistanceUnits) >= 0) {
+                    distanceUnit = DistanceUnit.parse(saAttributes.get(MilStdAttributes.DistanceUnits));
+                }
             }
 
             symbol.setModifierMap(modifiers);
@@ -2049,6 +2046,8 @@ public class MultiPointHandler {
             if(SymbolUtilities.isBasicShape(symbol.getSymbolID()))
                 symbol.setPatternFillType(patternFillType);
             symbol.setHideOptionalLabels(hideOptionalLabels);
+            symbol.setAltitudeUnit(altitudeUnit);
+            symbol.setDistanceUnit(distanceUnit);
 
             // Check grpahic modifiers variables.  If we set earlier, populate
             // the fields, otherwise, ignore.


### PR DESCRIPTION
For distances (widths) we are now able to pass in a conversion factor and label into the MilStdAttributes. This will allow us to pass in meters but be able to display it in different units.

For altitudes it is a little different, due to the fact that they are only text modifiers we assume that the modifiers are already converted by the time they are passed in. We allow the user to pass in units of measure labels for display but no conversions are done.