### PR TITLE
Access raw resources using R.raw instead of by a filename string

### DIFF
--- a/renderer-test-map/src/main/java/armyc2/c2sd/renderer/test2/MainActivity.java
+++ b/renderer-test-map/src/main/java/armyc2/c2sd/renderer/test2/MainActivity.java
@@ -102,7 +102,7 @@ public class MainActivity extends Activity {
 
         mir = MilStdIconRenderer.getInstance();
         String cacheDir = getApplicationContext().getCacheDir().getAbsoluteFile().getAbsolutePath();
-        mir.init(cacheDir);
+        mir.init(this, cacheDir);
         DisplayMetrics metrics = new DisplayMetrics();
         //getWindowManager().getDefaultDisplay().getRealMetrics(metrics);
         getWindowManager().getDefaultDisplay().getMetrics(metrics);

--- a/renderer-test/src/main/java/armyc2/c2sd/renderer/test1/MainActivity.java
+++ b/renderer-test/src/main/java/armyc2/c2sd/renderer/test1/MainActivity.java
@@ -105,7 +105,7 @@ public class MainActivity extends Activity {
     	
             mir = MilStdIconRenderer.getInstance();
             String cacheDir = getApplicationContext().getCacheDir().getAbsoluteFile().getAbsolutePath();
-            mir.init(cacheDir);
+            mir.init(this, cacheDir);
             DisplayMetrics metrics = new DisplayMetrics();
             //getWindowManager().getDefaultDisplay().getRealMetrics(metrics);
 			getWindowManager().getDefaultDisplay().getMetrics(metrics);

--- a/renderer-test3/src/main/java/armyc2/c2sd/renderer/test3/MainActivity.java
+++ b/renderer-test3/src/main/java/armyc2/c2sd/renderer/test3/MainActivity.java
@@ -193,7 +193,7 @@ public class MainActivity extends Activity {
 
         mir = MilStdIconRenderer.getInstance();
         String cacheDir = getApplicationContext().getCacheDir().getAbsoluteFile().getAbsolutePath();
-        mir.init(cacheDir);
+        mir.init(this, cacheDir);
         DisplayMetrics metrics = new DisplayMetrics();
         //getWindowManager().getDefaultDisplay().getRealMetrics(metrics);
         getWindowManager().getDefaultDisplay().getMetrics(metrics);

--- a/renderer/src/main/java/armyc2/c2sd/renderer/MilStdIconRenderer.java
+++ b/renderer/src/main/java/armyc2/c2sd/renderer/MilStdIconRenderer.java
@@ -1,5 +1,6 @@
 package armyc2.c2sd.renderer;
 
+import android.content.Context;
 import android.util.Log;
 import android.util.SparseArray;
 
@@ -31,7 +32,7 @@ public class MilStdIconRenderer
      *
      * @param cacheDir
      */
-    public synchronized void init(String cacheDir)// List<Typeface> fonts, List<String> xml
+    public synchronized void init(Context context, String cacheDir)// List<Typeface> fonts, List<String> xml
     {
         try {
             if (!_initSucces.get()) {
@@ -39,13 +40,13 @@ public class MilStdIconRenderer
                 _cacheDir = cacheDir;
 
                 // setup fonts
-                FontManager.getInstance().init(cacheDir);
+                FontManager.getInstance().init(context, cacheDir);
 
-                UnitDefTable.getInstance().init();
-                UnitFontLookup.getInstance().init();
-                SymbolDefTable.getInstance().init();
-                SinglePointLookup.getInstance().init();
-                TacticalGraphicLookup.getInstance().init();
+                UnitDefTable.getInstance().init(context);
+                UnitFontLookup.getInstance().init(context);
+                SymbolDefTable.getInstance().init(context);
+                SinglePointLookup.getInstance().init(context);
+                TacticalGraphicLookup.getInstance().init(context);
 
                 // PROTOTYPE SVG////////////////////////////////////////
                 // works, but half speed

--- a/renderer/src/main/java/armyc2/c2sd/renderer/utilities/FontManager.java
+++ b/renderer/src/main/java/armyc2/c2sd/renderer/utilities/FontManager.java
@@ -1,5 +1,7 @@
 package armyc2.c2sd.renderer.utilities;
 
+import armyc2.c2sd.singlepointrenderer.R;
+
 import java.io.BufferedOutputStream;
 import java.io.File;
 import java.io.FileOutputStream;
@@ -7,6 +9,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.UUID;
 
+import android.content.Context;
 import android.graphics.Paint;
 import android.graphics.Rect;
 import android.graphics.Typeface;
@@ -27,12 +30,6 @@ public class FontManager {
 	private Typeface _tfUnits = null;
 	private Typeface _tfSP = null;
 	private Typeface _tfTG = null;
-	private String unitFontName = "unitfont.ttf";
-	private String spFontName = "singlepointfont.ttf";
-	private String tgFontName = "tacticalgraphicsfont.ttf";//*/
-	/*private String unitFontName = "unitfont.otf";
-	private String spFontName = "singlepointfont.otf";
-	private String tgFontName = "tacticalgraphicsfont.otf";//*/
 	private String _cacheDir = "";
 	
 	private FontManager()
@@ -48,14 +45,14 @@ public class FontManager {
       return _instance;
     }
 	
-	public synchronized void init(String cacheDir)
+	public synchronized void init(Context context, String cacheDir)
 	{
 		if(!_initSuccess)
 		{
 			_cacheDir = cacheDir;
-			_tfUnits = loadFont(unitFontName);
-			_tfSP = loadFont(spFontName);
-			_tfTG = loadFont(tgFontName);
+			_tfUnits = loadFont(context, R.raw.unitfont);
+			_tfSP = loadFont(context, R.raw.singlepointfont);
+			_tfTG = loadFont(context, R.raw.tacticalgraphicsfont);
 			if( _tfUnits != null && _tfSP != null && _tfTG != null)
 				_initSuccess = true;
 			else
@@ -85,16 +82,15 @@ public class FontManager {
 		throw new Error("FontManager:  Must call \".init(String cacheDir)\" before using");
 	}
 	
-	private Typeface loadFont(String fontName)
+	private Typeface loadFont(Context context, int fontName)
 	{
-		String fontFolder = "res/raw/";
 		Typeface tf = null;
 		InputStream is = null;
 		try
 		{
 			
 			//InputStream fontStream = this.getClass().getClassLoader().getResourceAsStream("assets/fonts/unitfonts.ttf");
-			is = this.getClass().getClassLoader().getResourceAsStream(fontFolder + fontName);
+			is = context.getResources().openRawResource(fontName);
 			
 			if(is != null)
 			{

--- a/renderer/src/main/java/armyc2/c2sd/renderer/utilities/SinglePointLookup.java
+++ b/renderer/src/main/java/armyc2/c2sd/renderer/utilities/SinglePointLookup.java
@@ -4,6 +4,9 @@
 
 package armyc2.c2sd.renderer.utilities;
 
+import armyc2.c2sd.singlepointrenderer.R;
+
+import android.content.Context;
 import android.util.Log;
 
 import java.io.BufferedInputStream;
@@ -52,15 +55,14 @@ public class SinglePointLookup
         return _instance;
     }
 
-    public synchronized void init()
+    public synchronized void init(Context context)
     {
 
         if (_initCalled == false) {
             _instance = new SinglePointLookup();
 
             try {
-                DataInputStream dis = new DataInputStream(new BufferedInputStream(getClass().getClassLoader
-                        ().getResourceAsStream("res/raw/singlepoint.bin")));
+                DataInputStream dis = new DataInputStream(new BufferedInputStream(context.getResources().openRawResource(R.raw.singlepoint)));
                 readBinary(dis);
                 dis.close();
             } catch (IOException e) {

--- a/renderer/src/main/java/armyc2/c2sd/renderer/utilities/SymbolDefTable.java
+++ b/renderer/src/main/java/armyc2/c2sd/renderer/utilities/SymbolDefTable.java
@@ -9,6 +9,9 @@ package armyc2.c2sd.renderer.utilities;
  * import java.io.*; import java.util.HashMap; import java.util.Map;
  */
 
+import armyc2.c2sd.singlepointrenderer.R;
+
+import android.content.Context;
 import android.util.Log;
 
 import java.io.BufferedInputStream;
@@ -78,7 +81,7 @@ public class SymbolDefTable
         return _instance;
     }
 
-    public final synchronized void init()
+    public final synchronized void init(Context context)
     {
         if (_initCalled == false) {
             _SymbolDefinitionsB = new HashMap<>();
@@ -88,8 +91,7 @@ public class SymbolDefTable
             _SymbolDefDupsC = new ArrayList<>();
 
             try {
-                DataInputStream dis = new DataInputStream(new BufferedInputStream(this.getClass()
-                        .getClassLoader().getResourceAsStream("res/raw/symbolconstants.bin")));
+                DataInputStream dis = new DataInputStream(new BufferedInputStream(context.getResources().openRawResource(R.raw.symbolconstants)));
                 readBinary(dis);
                 dis.close();
             } catch (IOException e) {

--- a/renderer/src/main/java/armyc2/c2sd/renderer/utilities/TacticalGraphicLookup.java
+++ b/renderer/src/main/java/armyc2/c2sd/renderer/utilities/TacticalGraphicLookup.java
@@ -3,6 +3,9 @@
  */
 package armyc2.c2sd.renderer.utilities;
 
+import armyc2.c2sd.singlepointrenderer.R;
+
+import android.content.Context;
 import android.util.Log;
 
 import java.io.BufferedInputStream;
@@ -36,11 +39,10 @@ public class TacticalGraphicLookup
         return _instance;
     }
 
-    public synchronized void init()
+    public synchronized void init(Context context)
     {
         try {
-            DataInputStream dis = new DataInputStream(new BufferedInputStream(getClass().getClassLoader
-                    ().getResourceAsStream("res/raw/tacticalgraphic.bin")));
+            DataInputStream dis = new DataInputStream(new BufferedInputStream(context.getResources().openRawResource(R.raw.tacticalgraphic)));
             readBinary(dis);
             dis.close();
         } catch (IOException e) {

--- a/renderer/src/main/java/armyc2/c2sd/renderer/utilities/UnitDefTable.java
+++ b/renderer/src/main/java/armyc2/c2sd/renderer/utilities/UnitDefTable.java
@@ -4,6 +4,9 @@
 
 package armyc2.c2sd.renderer.utilities;
 
+import armyc2.c2sd.singlepointrenderer.R;
+
+import android.content.Context;
 import android.util.Log;
 
 import java.io.BufferedInputStream;
@@ -49,7 +52,7 @@ public class UnitDefTable
      * if(foo.getHierarchy().equalsIgnoreCase(hierarchy)) { return } } }
      */
 
-    public synchronized void init()
+    public synchronized void init(Context context)
     {
         if (_initCalled == false) {
 
@@ -60,8 +63,7 @@ public class UnitDefTable
             _UnitDefDupsC = new ArrayList<>();
 
             try {
-                DataInputStream dis = new DataInputStream(new BufferedInputStream(getClass().getClassLoader
-                        ().getResourceAsStream("res/raw/unitconstants.bin")));
+                DataInputStream dis = new DataInputStream(new BufferedInputStream(context.getResources().openRawResource(R.raw.unitconstants)));
                 readBinary(dis);
                 dis.close();
             } catch (IOException e) {

--- a/renderer/src/main/java/armyc2/c2sd/renderer/utilities/UnitFontLookup.java
+++ b/renderer/src/main/java/armyc2/c2sd/renderer/utilities/UnitFontLookup.java
@@ -4,6 +4,9 @@
 
 package armyc2.c2sd.renderer.utilities;
 
+import armyc2.c2sd.singlepointrenderer.R;
+
+import android.content.Context;
 import android.util.Log;
 
 import java.io.BufferedInputStream;
@@ -90,14 +93,13 @@ public class UnitFontLookup
         return _instance;
     }
 
-    public synchronized void init()
+    public synchronized void init(Context context)
     {
         if (_initCalled == false) {
             _instance = new UnitFontLookup();
 
             try {
-                DataInputStream dis = new DataInputStream(new BufferedInputStream(getClass().getClassLoader
-                        ().getResourceAsStream("res/raw/unitfontmappings.bin")));
+                DataInputStream dis = new DataInputStream(new BufferedInputStream(context.getResources().openRawResource(R.raw.unitfontmappings)));
                 readBinary(dis);
                 dis.close();
             } catch (IOException e) {

--- a/renderer/src/main/java/sec/web/render/SECWebRenderer.java
+++ b/renderer/src/main/java/sec/web/render/SECWebRenderer.java
@@ -3,6 +3,7 @@ package sec.web.render;
 // It requires that you import the plugins.jar from the jdk folder into the project libraries
 //import netscape.javascript.JSObject;
 
+import android.content.Context;
 import android.graphics.BitmapShader;
 import android.graphics.Shader;
 import android.util.SparseArray;
@@ -75,13 +76,13 @@ public final class SECWebRenderer /* extends Applet */ {
     private static boolean _initSuccess = false;
     
 
-    public static synchronized void init(String cacheDir) {
+    public static synchronized void init(Context context, String cacheDir) {
 
         try
         {
         	if(_initSuccess == false)
         	{
-                    MilStdIconRenderer.getInstance().init(cacheDir);
+                    MilStdIconRenderer.getInstance().init(context, cacheDir);
 	            //use SECWebRenderer.setLoggingLevel()
 	            
 	            //sets default value for single point symbology to have an outline.


### PR DESCRIPTION
Raw resources are being renamed for release builds in later versions of the gradle plugin which makes it impossible to retrieve a file by name unless you are running a debug version of your app.

Targeted remove_jcenter_bintray branch