### PR TITLE
Fix image info byte count in SinglePointRenderer for recycled bitmaps.

### DIFF
--- a/renderer/src/main/java/armyc2/c2sd/renderer/SinglePointRenderer.java
+++ b/renderer/src/main/java/armyc2/c2sd/renderer/SinglePointRenderer.java
@@ -1291,7 +1291,7 @@ public class SinglePointRenderer implements SettingsChangedEventListener
                         @Override
                         protected int sizeOf(String key, ImageInfo ii)
                         {
-                            return ii.getImage().getByteCount();// / 1024;
+                            return ii.getByteCount();// / 1024;
                         }
                     };
                 }
@@ -1304,7 +1304,7 @@ public class SinglePointRenderer implements SettingsChangedEventListener
                         @Override
                         protected int sizeOf(String key, ImageInfo ii)
                         {
-                            return ii.getImage().getByteCount();// / 1024;
+                            return ii.getByteCount();// / 1024;
                         }
                     };
                 }

--- a/renderer/src/main/java/armyc2/c2sd/renderer/utilities/ImageInfo.java
+++ b/renderer/src/main/java/armyc2/c2sd/renderer/utilities/ImageInfo.java
@@ -3,9 +3,7 @@ package armyc2.c2sd.renderer.utilities;
 import android.graphics.Bitmap;
 import android.graphics.Canvas;
 import android.graphics.Point;
-import android.graphics.PointF;
 import android.graphics.Rect;
-import android.graphics.RectF;
 import android.graphics.Bitmap.Config;
 
 public class ImageInfo {
@@ -14,6 +12,7 @@ public class ImageInfo {
 	private Rect _symbolBounds = null;
 	private Rect _imageBounds = null;
 	private Bitmap _image = null;
+	private int _byteCount = 0;
 	
 	public ImageInfo(ImageInfo original)
 	{
@@ -21,6 +20,7 @@ public class ImageInfo {
 		_symbolBounds = new Rect(original.getSymbolBounds());
 		_image = original.getImage();
 		_imageBounds = new Rect(original.getImageBounds());
+		_byteCount = original.getByteCount();
 	}
 	
 	public ImageInfo(Bitmap image, Point centerPoint, Rect symbolBounds)
@@ -30,6 +30,7 @@ public class ImageInfo {
 		_image = image;
 		
 		_imageBounds = RectUtilities.makeRect(0, 0, image.getWidth(), image.getHeight());
+		_byteCount = image.getAllocationByteCount();
 	}
 	
 	/**
@@ -66,6 +67,11 @@ public class ImageInfo {
 	public Rect getImageBounds()
 	{
 		return _imageBounds;
+	}
+
+	public int getByteCount()
+	{
+		return _byteCount;
 	}
 	
 	public ImageInfo getSquareImageInfo()


### PR DESCRIPTION
As of Android 0reo Bitmaps store their data again in native memory.

When application uses strategy to recycle bitmaps generated by mil-sym library, then SinglePointRenderer LRU cache fails to decrease its size, due to it gets byte count from recycled bitmap, which becomes 0 after recycling.

Current PR stores byte count on ImageInfo during construction and use its value to increase and decrease LRU cache size.