### PR TITLE
Basic shapes

### DIFF
--- a/renderer-test3/src/main/java/armyc2/c5isr/renderer/test3/MainActivity.java
+++ b/renderer-test3/src/main/java/armyc2/c5isr/renderer/test3/MainActivity.java
@@ -303,8 +303,8 @@ public class MainActivity extends Activity {
         //t.setText("Initializing Renderer");
         //depending on screen size and DPI you may want to change the font size.
         RendererSettings rs = RendererSettings.getInstance();
-        rs.setModifierFont("Arial", Typeface.BOLD, 18);
-        rs.setMPLabelFont("Arial", Typeface.BOLD, 18);
+        rs.setModifierFont("Arial", Typeface.BOLD, 48);
+        rs.setMPLabelFont("Arial", Typeface.BOLD, 48);
 
         //rs.setTextBackgroundMethod(RendererSettings.TextBackgroundMethod_COLORFILL);
 

--- a/renderer-test3/src/main/java/armyc2/c5isr/renderer/test3/MyView.java
+++ b/renderer-test3/src/main/java/armyc2/c5isr/renderer/test3/MyView.java
@@ -28,6 +28,7 @@ import java.io.IOException;
 
 import armyc2.c5isr.renderer.utilities.RendererSettings;
 import armyc2.c5isr.renderer.utilities.SymbolID;
+import armyc2.c5isr.renderer.utilities.SymbolUtilities;
 import armyc2.c5isr.web.render.GeoPixelConversion;
 import armyc2.c5isr.web.render.PointConverter;
 
@@ -80,24 +81,26 @@ public class MyView extends View {
 
             displayGeo(event);
 
+            int maxPointCount = 6;
             String symbolID  = MainActivity.lineType;
-            if (symbolID.length() >= 2 && symbolID.length() <= 8) {
-                symbolID = "" + SymbolID.Version_2525Dch1 + SymbolID.StandardIdentity_Context_Reality +
-                        SymbolID.StandardIdentity_Affiliation_Friend + symbolID.substring(0,2) +
-                        SymbolID.Status_Present + SymbolID.HQTFD_Unknown + SymbolID.Echelon_Team_Crew +
-                        symbolID.substring(2);
-            }
+            if (SymbolUtilities.isNumber(symbolID)) {
+                if (symbolID.length() >= 2 && symbolID.length() <= 8) {
+                    symbolID = "" + SymbolID.Version_2525Dch1 + SymbolID.StandardIdentity_Context_Reality +
+                            SymbolID.StandardIdentity_Affiliation_Friend + symbolID.substring(0, 2) +
+                            SymbolID.Status_Present + SymbolID.HQTFD_Unknown + SymbolID.Echelon_Team_Crew +
+                            symbolID.substring(2);
+                }
 
-            while (symbolID.length() < 30) {
-                symbolID += "0";
-            }
+                while (symbolID.length() < 30) {
+                    symbolID += "0";
+                }
 
-            int maxPointCount;
-            MSInfo msInfo = MSLookup.getInstance().getMSLInfo(symbolID);
-            if (msInfo != null) {
-                maxPointCount = msInfo.getMaxPointCount();
-            } else {
-                maxPointCount = 1000;
+                MSInfo msInfo = MSLookup.getInstance().getMSLInfo(symbolID);
+                if (msInfo != null) {
+                    maxPointCount = msInfo.getMaxPointCount();
+                } else {
+                    maxPointCount = 1000;
+                }
             }
 
             if (_points.size() >= maxPointCount || _points.size() >= 6) {

--- a/renderer-test3/src/main/java/armyc2/c5isr/renderer/test3/utility.java
+++ b/renderer-test3/src/main/java/armyc2/c5isr/renderer/test3/utility.java
@@ -14,6 +14,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
+import armyc2.c5isr.JavaLineArray.BasicShapes;
 import armyc2.c5isr.JavaLineArray.POINT2;
 import armyc2.c5isr.JavaLineArray.lineutility;
 import armyc2.c5isr.graphics2d.AffineTransform;
@@ -150,16 +151,6 @@ public final class utility {
                 lowerLatitude, rightLongitude);
         ArrayList<POINT2> pts2 = PixelsToLatLong(pts, converter);
 
-        if (symbolCode.length() >= 2 && symbolCode.length() <= 8) {
-            symbolCode = "" + SymbolID.Version_2525Dch1 + SymbolID.StandardIdentity_Context_Reality +
-                    SymbolID.StandardIdentity_Affiliation_Friend + symbolCode.substring(0,2) +
-                    SymbolID.Status_Present + SymbolID.HQTFD_Unknown + SymbolID.Echelon_Team_Crew +
-                    symbolCode.substring(2);
-        }
-
-        while (symbolCode.length() < 30) {
-            symbolCode += "0";
-        }
         boolean useDashArray=true;
         //uncomment the line to allow renderer to calculate the dashes
         //comment following line if client intends to calculate dashed lines to improve performance
@@ -199,21 +190,74 @@ public final class utility {
             if (!MainActivity.lineWidth.isEmpty())
                 attributes.put(MilStdAttributes.LineWidth, MainActivity.lineWidth);
             attributes.put(MilStdAttributes.UseDashArray, Boolean.toString(useDashArray));
-            MilStdSymbol mss= WebRenderer.RenderMultiPointAsMilStdSymbol("id", "name", "description", symbolCode, controlPtsStr, altitudeMode, scale, rectStr, modifiers, attributes);
-            String canRender = MultiPointHandler.canRenderMultiPoint(symbolCode, modifiers, pts2.size());
 
-            String strGeoJSON = WebRenderer.RenderSymbol("ID", "name", "description", symbolCode, controlPtsStr, altitudeMode , scale, rectStr, modifiers, attributes,WebRenderer.OUTPUT_FORMAT_GEOJSON);
-            Log.i(symbolCode, strGeoJSON);
-            String strGeoSVG = WebRenderer.RenderSymbol("ID", "name", "description", symbolCode, controlPtsStr, altitudeMode , scale, rectStr, modifiers, attributes,WebRenderer.OUTPUT_FORMAT_GEOSVG);
-            Log.i(symbolCode, strGeoSVG);
+         switch (symbolCode) {
+             case "LINE": {
+                 MilStdSymbol mss = WebRenderer.RenderBasicShapeAsMilStdSymbol("id", "name", "description", BasicShapes.LINE, controlPtsStr, altitudeMode, scale, rectStr, modifiers, attributes);
+                 drawShapeInfosGE(g2d, mss.getSymbolShapes(), useDashArray, mss.getSymbolID(), converter);
+                 drawShapeInfosText(g2d, mss.getModifierShapes(), mss.getTextColor(), converter);
+                 break;
+             }
+             case "AREA": {
+                 MilStdSymbol mss = WebRenderer.RenderBasicShapeAsMilStdSymbol("id", "name", "description", BasicShapes.AREA, controlPtsStr, altitudeMode, scale, rectStr, modifiers, attributes);
+                 drawShapeInfosGE(g2d, mss.getSymbolShapes(), useDashArray, mss.getSymbolID(), converter);
+                 drawShapeInfosText(g2d, mss.getModifierShapes(), mss.getTextColor(), converter);
+                 break;
+             }
+             case "ELLIPSE": {
+                 MilStdSymbol mss = WebRenderer.RenderBasicShapeAsMilStdSymbol("id", "name", "description", BasicShapes.ELLIPSE, controlPtsStr, altitudeMode, scale, rectStr, modifiers, attributes);
+                 drawShapeInfosGE(g2d, mss.getSymbolShapes(), useDashArray, mss.getSymbolID(), converter);
+                 drawShapeInfosText(g2d, mss.getModifierShapes(), mss.getTextColor(), converter);
+                 break;
+             }
+             case "CIRCLE": {
+                 MilStdSymbol mss = WebRenderer.RenderBasicShapeAsMilStdSymbol("id", "name", "description", BasicShapes.CIRCLE, controlPtsStr, altitudeMode, scale, rectStr, modifiers, attributes);
+                 drawShapeInfosGE(g2d, mss.getSymbolShapes(), useDashArray, mss.getSymbolID(), converter);
+                 drawShapeInfosText(g2d, mss.getModifierShapes(), mss.getTextColor(), converter);
+                 break;
+             }
+             case "RECTANGLE": {
+                 MilStdSymbol mss = WebRenderer.RenderBasicShapeAsMilStdSymbol("id", "name", "description", BasicShapes.RECTANGLE, controlPtsStr, altitudeMode, scale, rectStr, modifiers, attributes);
+                 drawShapeInfosGE(g2d, mss.getSymbolShapes(), useDashArray, mss.getSymbolID(), converter);
+                 drawShapeInfosText(g2d, mss.getModifierShapes(), mss.getTextColor(), converter);
+                 break;
+             }
+             case "POINT": {
+                 MilStdSymbol mss = WebRenderer.RenderBasicShapeAsMilStdSymbol("id", "name", "description", BasicShapes.POINT, controlPtsStr, altitudeMode, scale, rectStr, modifiers, attributes);
+                 drawShapeInfosGE(g2d, mss.getSymbolShapes(), useDashArray, mss.getSymbolID(), converter);
+                 drawShapeInfosText(g2d, mss.getModifierShapes(), mss.getTextColor(), converter);
+                 break;
+             }
+             default: { // 2525 symbol code
+                 if (symbolCode.length() >= 2 && symbolCode.length() <= 8) {
+                     symbolCode = "" + SymbolID.Version_2525Dch1 + SymbolID.StandardIdentity_Context_Reality +
+                             SymbolID.StandardIdentity_Affiliation_Friend + symbolCode.substring(0, 2) +
+                             SymbolID.Status_Present + SymbolID.HQTFD_Unknown + SymbolID.Echelon_Team_Crew +
+                             symbolCode.substring(2);
+                 }
 
-            if (canRender.equals("true")) {
-                // drawControlPoints(g2d, mss.getCoordinates(), converter);
-                drawShapeInfosGE(g2d, mss.getSymbolShapes(),useDashArray,mss.getSymbolID(),converter);
-                drawShapeInfosText(g2d, mss.getModifierShapes(),mss.getTextColor(),converter);
-            } else {
-                Log.e("Utility", "Cannot Render multipoint: " + canRender);
-            }
+                 while (symbolCode.length() < 30) {
+                     symbolCode += "0";
+                 }
+
+                 MilStdSymbol mss = WebRenderer.RenderMultiPointAsMilStdSymbol("id", "name", "description", symbolCode, controlPtsStr, altitudeMode, scale, rectStr, modifiers, attributes);
+                 String canRender = MultiPointHandler.canRenderMultiPoint(symbolCode, modifiers, pts2.size());
+
+                 String strGeoJSON = WebRenderer.RenderSymbol("ID", "name", "description", symbolCode, controlPtsStr, altitudeMode, scale, rectStr, modifiers, attributes, WebRenderer.OUTPUT_FORMAT_GEOJSON);
+                 Log.i(symbolCode, strGeoJSON);
+                 String strGeoSVG = WebRenderer.RenderSymbol("ID", "name", "description", symbolCode, controlPtsStr, altitudeMode, scale, rectStr, modifiers, attributes, WebRenderer.OUTPUT_FORMAT_GEOSVG);
+                 Log.i(symbolCode, strGeoSVG);
+
+                 if (canRender.equals("true")) {
+                     // drawControlPoints(g2d, mss.getCoordinates(), converter);
+                     drawShapeInfosGE(g2d, mss.getSymbolShapes(), useDashArray, mss.getSymbolID(), converter);
+                     drawShapeInfosText(g2d, mss.getModifierShapes(), mss.getTextColor(), converter);
+                 } else {
+                     Log.e("Utility", "Cannot Render multipoint: " + canRender);
+                 }
+                 break;
+             }
+         }
     }
 
     private static String getRectString(double deltax, double deltay) {

--- a/renderer/src/main/java/armyc2/c5isr/JavaLineArray/BasicShapes.java
+++ b/renderer/src/main/java/armyc2/c5isr/JavaLineArray/BasicShapes.java
@@ -1,0 +1,98 @@
+package armyc2.c5isr.JavaLineArray;
+
+public final class BasicShapes {
+    /**
+     * Anchor Points: This symbol requires at least two anchor points, points 1
+     * and 2, to define the line. Additional points can be defined to extend the
+     * line.
+     * <p>
+     * Size/Shape: The first and last anchor points determine the length of the
+     * line.
+     * <p>
+     * Orientation: Orientation is determined by the order in which the anchor points are entered.
+     * <p>
+     * Modifiers: T
+     *
+     * @see armyc2.c5isr.renderer.utilities.DrawRules#LINE1
+     */
+    public static final int LINE = TacticalLines.BS_LINE;
+
+    /**
+     * Anchor Points: This symbol requires at least three anchor points to
+     * define the boundary of the area. Add as many points as necessary to
+     * accurately reflect the area’s size and shape.
+     * <p>
+     * Size/Shape: Determined by the anchor points. The information fields
+     * should be moveable and scalable as a block within the area.
+     * <p>
+     * Modifiers: T
+     *
+     * @see armyc2.c5isr.renderer.utilities.DrawRules#AREA1
+     */
+    public static final int AREA = TacticalLines.BS_AREA;
+
+    /**
+     * Anchor Points: This symbol requires one anchor point. This anchor point
+     * represents the center of an ellipse and, therefore, the geographic
+     * location of that ellipse.
+     * <p>
+     * Size/Shape: The size and shape of this symbol is determined by three
+     * additional numeric values; A major axis radius, a minor axis radius, and
+     * a rotation angle. The radii should be expressed in the appropriate map
+     * distance units.
+     * <p>
+     * Orientation: The orientation of this symbol is determined by the rotation
+     * angle provided, where 0 degrees is east/west and a positive rotation
+     * angle rotates the ellipse in a counter-clockwise direction.
+     * <p>
+     * Modifiers: AM, AN, T
+     *
+     * @see armyc2.c5isr.renderer.utilities.DrawRules#ELLIPSE1
+     */
+    public static final int ELLIPSE = TacticalLines.PBS_ELLIPSE;
+
+    /**
+     * Anchor Points: This symbol requires one (1) anchor point and a radius.
+     * Point 1 defines the center point of the symbol.
+     * <p>
+     * Size/Shape: Size: The radius defines the size.
+     * <p>
+     * Orientation: Not applicable
+     * <p>
+     * Modifiers: AM, T
+     *
+     * @see armyc2.c5isr.renderer.utilities.DrawRules#CIRCULAR1
+     */
+    public static final int CIRCLE = TacticalLines.PBS_CIRCLE;
+
+    /**
+     * Anchor Points: This symbol requires one (1) anchor point to define the
+     * center of the area.
+     * <p>
+     * Size/Shape: Size is determined by the anchor point, the length (in meters)
+     * and width (in meters).
+     * <p>
+     * Orientation: The orientation of this symbol is determined by the rotation
+     * angle provided, where 0 degrees is east/west and a positive rotation
+     * angle rotates the ellipse in a clockwise direction.
+     * <p>
+     * Modifiers: AM, AN, T
+     *
+     * @see armyc2.c5isr.renderer.utilities.DrawRules#RECTANGULAR2
+     */
+    public static final int RECTANGLE = TacticalLines.PBS_RECTANGLE;
+
+    /**
+     * Anchor Points: This symbol requires one anchor point. The center point
+     * defines/is the center of the symbol.
+     * <p>
+     * Size/Shape: Line width defines the size of the point. The radius defines the size of the outline.
+     * <p>
+     * Orientation: Not applicable
+     * <p>
+     * Modifiers: AM, T
+     *
+     * @see armyc2.c5isr.renderer.utilities.DrawRules#POINT2
+     */
+    public static final int POINT = TacticalLines.BBS_POINT;
+}

--- a/renderer/src/main/java/armyc2/c5isr/JavaLineArray/CELineArray.java
+++ b/renderer/src/main/java/armyc2/c5isr/JavaLineArray/CELineArray.java
@@ -136,6 +136,7 @@ public final class CELineArray {
                 case TacticalLines.DOUBLEA:
                 case TacticalLines.LWFENCE:
                 case TacticalLines.HWFENCE:
+                case TacticalLines.BBS_LINE:
                 case TacticalLines.SINGLEC:
                 case TacticalLines.DOUBLEC:
                 case TacticalLines.TRIPLE:

--- a/renderer/src/main/java/armyc2/c5isr/JavaLineArray/Channels.java
+++ b/renderer/src/main/java/armyc2/c5isr/JavaLineArray/Channels.java
@@ -592,6 +592,9 @@ public final class Channels {
                 case TacticalLines.DFENCE:
                     lTotal = 4 * vblCounter + 4 * lTotal;
                     break;
+                case TacticalLines.BBS_LINE:
+                    lTotal = 2 * vblCounter + 1;
+                    break;
                 default:
                     lTotal = 2 * vblCounter;
                     break;
@@ -839,6 +842,7 @@ public final class Channels {
                 case TacticalLines.DOUBLEC:
                 case TacticalLines.SINGLEC:
                 case TacticalLines.HWFENCE:
+                case TacticalLines.BBS_LINE:
                 case TacticalLines.LWFENCE:
                 case TacticalLines.DOUBLEA:
                 case TacticalLines.UNSP:
@@ -1243,7 +1247,7 @@ public final class Channels {
             //end declarations
 
             //initializations
-            if (vblChannelWidth < 5) {
+            if (vblChannelWidth < 5 && vbiDrawThis != TacticalLines.BBS_LINE) {
                 vblChannelWidth = 5;
             }
 
@@ -1340,6 +1344,7 @@ public final class Channels {
                 case TacticalLines.DOUBLEC:
                 case TacticalLines.SINGLEC:
                 case TacticalLines.HWFENCE:
+                case TacticalLines.BBS_LINE:
                 case TacticalLines.LWFENCE:
                 case TacticalLines.UNSP:
                 case TacticalLines.DOUBLEA:
@@ -1364,6 +1369,7 @@ public final class Channels {
                         case TacticalLines.DOUBLEC:
                         case TacticalLines.SINGLEC:
                         case TacticalLines.HWFENCE:
+                        case TacticalLines.BBS_LINE:
                         case TacticalLines.LWFENCE:
                         case TacticalLines.UNSP:
                         case TacticalLines.DOUBLEA:
@@ -1684,7 +1690,8 @@ public final class Channels {
                     lEllipseCounter = vblLowerCounter + vblUpperCounter;
                     //following section only for lines with repeating features, e.g. DOUBLEA
                     //if(segments!=null &&
-                    if (vbiDrawThis != TacticalLines.CHANNEL &&
+                    if (vbiDrawThis != TacticalLines.BBS_LINE &&
+                            vbiDrawThis != TacticalLines.CHANNEL &&
                             vbiDrawThis != TacticalLines.CHANNEL_DASHED &&
                             vbiDrawThis != TacticalLines.CHANNEL_FLARED &&
                             vbiDrawThis != TacticalLines.SPT_STRAIGHT &&
@@ -1839,6 +1846,14 @@ public final class Channels {
                             }
                         }
                     }
+                    break;
+                case TacticalLines.BBS_LINE:
+                    pLinePoints=new POINT2[vblLowerCounter+vblUpperCounter+1];
+                    for(j=0;j<vblLowerCounter;j++)
+                        pLinePoints[j]=pLowerLinePoints[j];
+                    for(j=0;j<vblUpperCounter;j++)
+                        pLinePoints[j+vblLowerCounter]=pUpperLinePoints[vblUpperCounter-1-j];
+                    pLinePoints[pLinePoints.length-1]=pLinePoints[0];
                     break;
                 case TacticalLines.SPT:
                 case TacticalLines.SPT_STRAIGHT:
@@ -2316,7 +2331,19 @@ public final class Channels {
             ArrayList<Shape2>fillShapes=getAXADFillShapes(vbiDrawThis, pLinePoints);
             if(fillShapes != null && fillShapes.size()>0)
                 shapes.addAll(0,fillShapes);
-            
+
+            //diagnostic
+            if(vbiDrawThis==TacticalLines.BBS_LINE)
+            {
+                //shapes.remove(1);
+                shape=new Shape2(Shape2.SHAPE_TYPE_POLYLINE);
+                shape.moveTo(pOriginalLinePoints[0]);
+                for(j=1;j<pOriginalLinePoints.length;j++)
+                    shape.lineTo(pOriginalLinePoints[j]);
+                shapes.add(shape);
+            }
+            //end section
+
             lResult=lResultCounter;
             //FillPoints(pLinePoints,pLinePoints.length);
             //clean up
@@ -2354,6 +2381,15 @@ public final class Channels {
             int n=pLinePoints.length;
             switch(lineType)
             {
+                case TacticalLines.BBS_LINE:
+                    shape=new Shape2(Shape2.SHAPE_TYPE_FILL);
+                    shape.moveTo(pLinePoints[0]);
+                    //for(j=1;j<pLinePoints.length;j++)
+                    for(j=1;j<n;j++)
+                    {
+                        shape.lineTo(pLinePoints[j]);
+                    }
+                    break;
                 case TacticalLines.CHANNEL:
                 case TacticalLines.CHANNEL_FLARED:
                 case TacticalLines.CHANNEL_DASHED:

--- a/renderer/src/main/java/armyc2/c5isr/JavaLineArray/TacticalLines.java
+++ b/renderer/src/main/java/armyc2/c5isr/JavaLineArray/TacticalLines.java
@@ -4,6 +4,29 @@ package armyc2.c5isr.JavaLineArray;
  * Class to provide the symbols with values corresponding to the Mil-Standard-2525 hierarchy.
  */
 public final class TacticalLines {
+    public static final int BS_LINE=10000000;
+    public static final int BS_AREA=11000000;
+    @Deprecated
+    public static final int BS_CROSS=12000000;
+    @Deprecated
+    public static final int BS_ELLIPSE=13000000;
+    public static final int PBS_ELLIPSE=13000001;
+    public static final int PBS_CIRCLE=13000002;
+    @Deprecated
+    public static final int BS_RECTANGLE=14000000;
+    public static final int PBS_RECTANGLE=14000001;
+    @Deprecated
+    public static final int PBS_SQUARE=14000002;
+    @Deprecated
+    public static final int BBS_LINE=15000000;
+    @Deprecated
+    public static final int BBS_AREA=15000001;
+    public static final int BBS_POINT=15000002;
+    @Deprecated
+    public static final int BBS_RECTANGLE=15000003;
+    @Deprecated
+    public static final int BS_BBOX=15000004;
+
     public static final int PZ = 22138000;
     public static final int LZ = 22137000;
     public static final int DZ = 22135000;

--- a/renderer/src/main/java/armyc2/c5isr/JavaLineArray/arraysupport.java
+++ b/renderer/src/main/java/armyc2/c5isr/JavaLineArray/arraysupport.java
@@ -2054,6 +2054,80 @@ public final class arraysupport {
             //resize the array and get the line array
             //for the specified non-channel line type
             switch (lineType) {
+                case TacticalLines.BBS_AREA:
+                    lineutility.getExteriorPoints(pLinePoints, vblSaveCounter, lineType, false);
+                    acCounter = vblSaveCounter;
+                    break;
+                case TacticalLines.BS_CROSS:
+                    pt0 = new POINT2(pLinePoints[0]);
+                    pLinePoints[0] = new POINT2(pt0);
+                    pLinePoints[0].x -= 10;
+                    pLinePoints[1] = new POINT2(pt0);
+                    pLinePoints[1].x += 10;
+                    pLinePoints[1].style = 10;
+                    pLinePoints[2] = new POINT2(pt0);
+                    pLinePoints[2].y += 10;
+                    pLinePoints[3] = new POINT2(pt0);
+                    pLinePoints[3].y -= 10;
+                    acCounter = 4;
+                    break;
+                case TacticalLines.BS_RECTANGLE:
+                    lineutility.CalcMBRPoints(pLinePoints, pLinePoints.length, pt0, pt2);   //pt0=ul, pt1=lr
+                    pt1 = new POINT2(pt0);
+                    pt1.x = pt2.x;
+                    pt3 = new POINT2(pt0);
+                    pt3.y = pt2.y;
+                    pLinePoints = new POINT2[5];
+                    pLinePoints[0] = new POINT2(pt0);
+                    pLinePoints[1] = new POINT2(pt1);
+                    pLinePoints[2] = new POINT2(pt2);
+                    pLinePoints[3] = new POINT2(pt3);
+                    pLinePoints[4] = new POINT2(pt0);
+                    acCounter = 5;
+                    break;
+                case TacticalLines.BBS_RECTANGLE:
+                    //double xmax=pLinePoints[0].x,xmin=pLinePoints[1].x,ymax=pLinePoints[0].y,ymin=pLinePoints[1].y;
+                    //double xmax=pLinePoints[2].x,xmin=pLinePoints[0].x,ymax=pLinePoints[2].y,ymin=pLinePoints[0].y;
+                    double buffer = pLinePoints[0].style;
+
+                    pOriginalLinePoints = new POINT2[5];
+                    pOriginalLinePoints[0] = new POINT2(pLinePoints[0]);
+                    pOriginalLinePoints[1] = new POINT2(pLinePoints[1]);
+                    pOriginalLinePoints[2] = new POINT2(pLinePoints[2]);
+                    pOriginalLinePoints[3] = new POINT2(pLinePoints[3]);
+                    pOriginalLinePoints[4] = new POINT2(pLinePoints[0]);
+
+                    //clockwise orientation
+                    pt0 = pLinePoints[0];
+                    pt0.x -= buffer;
+                    pt0.y -= buffer;
+                    pt1 = pLinePoints[1];
+                    pt1.x += buffer;
+                    pt1.y -= buffer;
+                    pt2 = pLinePoints[2];
+                    pt2.x += buffer;
+                    pt2.y += buffer;
+                    pt3 = pLinePoints[3];
+                    pt3.x -= buffer;
+                    pt3.y += buffer;
+                    pLinePoints = new POINT2[5];
+                    pLinePoints[0] = new POINT2(pt0);
+                    pLinePoints[1] = new POINT2(pt1);
+                    pLinePoints[2] = new POINT2(pt2);
+                    pLinePoints[3] = new POINT2(pt3);
+                    pLinePoints[4] = new POINT2(pt0);
+                    vblSaveCounter = 5;
+                    acCounter = 5;
+                    break;
+                case TacticalLines.BS_ELLIPSE:
+                    pt0 = pLinePoints[0];//the center of the ellipse
+                    pt1 = pLinePoints[1];//the width of the ellipse
+                    pt2 = pLinePoints[2];//the height of the ellipse
+                    //pLinePoints=getEllipsePoints(pt0,pt1,pt2);
+                    double azimuth = pLinePoints[3].x;
+                    pLinePoints = getRotatedEllipsePoints(pt0, pt1, pt2, azimuth, lineType);
+                    acCounter = 37;
+                    break;
                 case TacticalLines.OVERHEAD_WIRE:
                     acCounter = getOverheadWire(tg, pLinePoints, vblSaveCounter);
                     break;
@@ -3766,6 +3840,8 @@ public final class arraysupport {
                 case TacticalLines.RETAIN:
                 case TacticalLines.SECURE:
                 case TacticalLines.SEIZE:
+                case TacticalLines.BS_RECTANGLE:
+                case TacticalLines.BBS_RECTANGLE:
                 //add these
                 case TacticalLines.AIRFIELD:
                 case TacticalLines.CORDONKNOCK:
@@ -3826,6 +3902,23 @@ public final class arraysupport {
                         secondPoly[i] = pLinePoints[i + 8];
                     }
                     addPolyline(secondPoly, 6, shapes);
+                    break;
+                case TacticalLines.BBS_AREA:
+                case TacticalLines.BBS_RECTANGLE:
+                    shape = new Shape2(Shape2.SHAPE_TYPE_FILL);
+                    shape.moveTo(pLinePoints[0]);
+                    for (j = 0; j < vblSaveCounter; j++) {
+                        shape.lineTo(pLinePoints[j]);
+                    }
+                    shapes.add(shape);
+
+                    shape = new Shape2(Shape2.SHAPE_TYPE_POLYLINE);
+                    shape.moveTo(pOriginalLinePoints[0]);
+                    for (j = 1; j < vblSaveCounter; j++) {
+                        shape.lineTo(pOriginalLinePoints[j]);
+                    }
+                    shapes.add(shape);
+
                     break;
                 case TacticalLines.DIRATKGND:
                     //create two shapes. the first shape is for the line

--- a/renderer/src/main/java/armyc2/c5isr/JavaLineArray/countsupport.java
+++ b/renderer/src/main/java/armyc2/c5isr/JavaLineArray/countsupport.java
@@ -63,6 +63,12 @@ public final class countsupport
             //end delcarations
             switch (vbiDrawThis)
             {
+                case TacticalLines.BS_ELLIPSE:
+                    count=37;
+                    break;
+                case TacticalLines.BS_CROSS:
+                    count=4;
+                    break;
                 case TacticalLines.OVERHEAD_WIRE:
                     count=vblCounter*15;    //15 points per segment
                     break;
@@ -389,6 +395,9 @@ public final class countsupport
                 case TacticalLines.SFENCE:
                 case TacticalLines.DFENCE:
                     count = Channels.GetTripleCountDouble(pLinePoints, vblCounter, vbiDrawThis);
+                    break;
+                case TacticalLines.BBS_LINE:
+                    count=2*vblCounter;
                     break;
                 case TacticalLines.LC:
                     pUpperLinePoints = Channels.GetChannelArray2Double(1,pUpperLinePoints,1,vblCounter,vbiDrawThis,(int) arraysupport.getScaledSize(20, tg.get_LineThickness(), tg.get_patternScale()));

--- a/renderer/src/main/java/armyc2/c5isr/JavaTacticalRenderer/Modifier2.java
+++ b/renderer/src/main/java/armyc2/c5isr/JavaTacticalRenderer/Modifier2.java
@@ -2142,6 +2142,14 @@ public class Modifier2 {
                 case TacticalLines.RECTANGULAR_TARGET:
                 case TacticalLines.LINE:
                 case TacticalLines.ASLTXING:
+                case TacticalLines.BS_LINE:
+                case TacticalLines.BS_AREA:
+                case TacticalLines.BBS_LINE:
+                case TacticalLines.BBS_AREA:
+                case TacticalLines.PBS_CIRCLE:
+                case TacticalLines.PBS_ELLIPSE:
+                case TacticalLines.PBS_RECTANGLE:
+                case TacticalLines.BBS_POINT:
                     origPoints = lineutility.getDeepCopy(tg.Pixels);
                     break;
                 default:    //exit early for those not applicable
@@ -2223,6 +2231,44 @@ public class Modifier2 {
                 case TacticalLines.PL:
                     AddIntegralAreaModifier(tg, label + TSpace + tg.get_Name(), toEnd, T1LineFactor, pt0, pt1, false);
                     AddIntegralAreaModifier(tg, label + TSpace + tg.get_Name(), toEnd, T1LineFactor, ptLast, ptNextToLast, false);
+                    break;
+                case TacticalLines.BS_LINE:
+                case TacticalLines.BBS_LINE:
+                    if (tg.get_T1() == null || tg.get_T1().isEmpty()) {
+                        AddIntegralAreaModifier(tg, tg.get_Name(), toEnd, T1LineFactor, pt0, pt1, false);
+                        AddIntegralAreaModifier(tg, tg.get_Name(), toEnd, T1LineFactor, ptLast, ptNextToLast, false);
+                    } else {
+                        if (tg.get_T1().equalsIgnoreCase("1")) {
+                            for (j = 0; j < tg.Pixels.size() - 1; j++) {
+                                AddIntegralAreaModifier(tg, tg.get_Name(), aboveMiddle, 0, tg.Pixels.get(j), tg.Pixels.get(j + 1), false);
+                            }
+                        } else if (tg.get_T1().equalsIgnoreCase("2")) {
+                            AddIntegralAreaModifier(tg, tg.get_Name(), toEnd, T1LineFactor, pt0, pt1, false);
+                            AddIntegralAreaModifier(tg, tg.get_Name(), toEnd, T1LineFactor, ptLast, ptNextToLast, false);
+                        } else if (tg.get_T1().equalsIgnoreCase("3")) {
+                            //either end of the polyline
+                            dist = lineutility.CalcDistanceDouble(pt0, pt1);
+                            stringWidth = metrics.stringWidth(tg.get_Name());
+                            stringWidth /= 2;
+                            pt2 = lineutility.ExtendAlongLineDouble2(pt1, pt0, dist + stringWidth);
+                            AddIntegralAreaModifier(tg, tg.get_Name(), area, 0, pt2, pt2, false);
+                            dist = lineutility.CalcDistanceDouble(ptNextToLast, ptLast);
+                            pt2 = lineutility.ExtendAlongLineDouble2(ptNextToLast, ptLast, dist + stringWidth);
+                            AddIntegralAreaModifier(tg, tg.get_Name(), area, 0, pt2, pt2, false);
+                            //the intermediate points
+                            for (j = 1; j < tg.Pixels.size() - 1; j++) {
+                                AddIntegralAreaModifier(tg, tg.get_Name(), area, 0, tg.Pixels.get(j), tg.Pixels.get(j), false);
+                            }
+                        } else //t1 is set inadvertantly or for other graphics
+                        {
+                            AddIntegralAreaModifier(tg, tg.get_Name(), toEnd, T1LineFactor, pt0, pt1, false);
+                            AddIntegralAreaModifier(tg, tg.get_Name(), toEnd, T1LineFactor, ptLast, ptNextToLast, false);
+                        }
+                    }
+                    break;
+                case TacticalLines.BS_AREA:
+                case TacticalLines.BBS_AREA:
+                    AddIntegralAreaModifier(tg, tg.get_Name(), area, 0, ptCenter, ptCenter, false);
                     break;
                 case TacticalLines.FEBA:
                     AddIntegralAreaModifier(tg, label, toEnd, 0, pt0, pt1, false);
@@ -2566,6 +2612,12 @@ public class Modifier2 {
                 case TacticalLines.RECTANGULAR:
                 case TacticalLines.CIRCULAR:
                     AddIntegralAreaModifier(tg, ap, area, 0, pt0, pt0, false);
+                    break;
+                case TacticalLines.PBS_CIRCLE:
+                case TacticalLines.PBS_ELLIPSE:
+                case TacticalLines.PBS_RECTANGLE:
+                case TacticalLines.BBS_POINT:
+                    AddIntegralAreaModifier(tg, tg.get_Name(), area, 0, pt0, pt0, false);
                     break;
                 case TacticalLines.RECTANGULAR_TARGET:
                     stringWidth = metrics.stringWidth(tg.get_Name());
@@ -3422,6 +3474,8 @@ public class Modifier2 {
                 return;
             }
             switch (tg.get_LineType()) {
+                case TacticalLines.BS_RECTANGLE:
+                case TacticalLines.BBS_RECTANGLE:
                 case TacticalLines.CONVOY:
                 case TacticalLines.HCONVOY:
                 case TacticalLines.BREACH:
@@ -3447,6 +3501,7 @@ public class Modifier2 {
                 case TacticalLines.CUED_ACQUISITION:
                 case TacticalLines.CIRCULAR:
                 case TacticalLines.BDZ:
+                case TacticalLines.BBS_POINT:
                 case TacticalLines.FSA_CIRCULAR:
                 case TacticalLines.NOTACK:
                 case TacticalLines.ATI_CIRCULAR:
@@ -3550,6 +3605,15 @@ public class Modifier2 {
 
             shiftModifierPath(tg, pt0, pt1, ptLast, ptNextToLast);
             switch (linetype) {
+                case TacticalLines.BS_RECTANGLE:
+                case TacticalLines.BBS_RECTANGLE:
+                    pts = new POINT2[4];
+                    for (j = 0; j < 4; j++) {
+                        pts[j] = tg.Pixels.get(j);
+                    }
+                    ptCenter = lineutility.CalcCenterPointDouble2(pts, 4);
+                    AddIntegralAreaModifier(tg, tg.get_Name(), area, -0.125 * csFactor, ptCenter, ptCenter, false);
+                    break;
                 case TacticalLines.CONVOY:
                 case TacticalLines.HCONVOY:
                     pt2 = lineutility.MidPointDouble(tg.Pixels.get(0), tg.Pixels.get(3), 0);

--- a/renderer/src/main/java/armyc2/c5isr/JavaTacticalRenderer/clsChannelUtility.java
+++ b/renderer/src/main/java/armyc2/c5isr/JavaTacticalRenderer/clsChannelUtility.java
@@ -124,6 +124,7 @@ public final class clsChannelUtility {
                 case TacticalLines.DOUBLEA:
                 case TacticalLines.LWFENCE:
                 case TacticalLines.HWFENCE:
+                case TacticalLines.BBS_LINE:
                 case TacticalLines.SINGLEC:
                 case TacticalLines.DOUBLEC:
                 case TacticalLines.TRIPLE:
@@ -511,6 +512,15 @@ public final class clsChannelUtility {
                     pixels2 = new double[pixels.length];
                     n = pixels.length;
                     //for (j = 0; j < pixels.length; j++) 
+                    for (j = 0; j < n; j++) {
+                        pixels2[j] = pixels[j];
+                    }
+                    break;
+                case TacticalLines.BBS_LINE:
+                    channelWidth = 8 * tg.Pixels.get(0).style;  //was 20 1-10-13
+                    pixels2 = new double[pixels.length];
+                    n = pixels.length;
+                    //for (j = 0; j < pixels.length; j++)
                     for (j = 0; j < n; j++) {
                         pixels2[j] = pixels[j];
                     }

--- a/renderer/src/main/java/armyc2/c5isr/JavaTacticalRenderer/clsUtility.java
+++ b/renderer/src/main/java/armyc2/c5isr/JavaTacticalRenderer/clsUtility.java
@@ -125,6 +125,7 @@ public final class clsUtility {
             case TacticalLines.RECTANGULAR:
             case TacticalLines.CUED_ACQUISITION:
             case TacticalLines.CIRCULAR:
+            case TacticalLines.PBS_CIRCLE:
             case TacticalLines.BDZ:
             case TacticalLines.FSA_CIRCULAR:
             case TacticalLines.NOTACK:
@@ -147,6 +148,7 @@ public final class clsUtility {
             case TacticalLines.LAUNCH_AREA:
             case TacticalLines.DEFENDED_AREA_CIRCULAR:
             case TacticalLines.SHIP_AOI_CIRCULAR:
+            case TacticalLines.PBS_ELLIPSE:
             case TacticalLines.RANGE_FAN:
             case TacticalLines.RANGE_FAN_SECTOR:
             case TacticalLines.RADAR_SEARCH:
@@ -344,6 +346,8 @@ public final class clsUtility {
     public static boolean isClosedPolygon(int linetype) {
         boolean result = false;
         switch (linetype) {
+            case TacticalLines.BBS_AREA:
+            case TacticalLines.BS_BBOX:
             case TacticalLines.AT:
             case TacticalLines.DEPICT:
             case TacticalLines.DZ:
@@ -372,6 +376,7 @@ public final class clsUtility {
             case TacticalLines.JTAA:
             case TacticalLines.SAA:
             case TacticalLines.SGAA:
+            case TacticalLines.BS_AREA:
             case TacticalLines.ASSAULT:
             case TacticalLines.ATKPOS:
             case TacticalLines.OBJ:
@@ -705,6 +710,8 @@ public final class clsUtility {
                                 case TacticalLines.RANGE_FAN:
                                 case TacticalLines.RANGE_FAN_SECTOR:
                                 case TacticalLines.RADAR_SEARCH:
+                                case TacticalLines.BBS_AREA:
+                                case TacticalLines.BBS_RECTANGLE:
                                     shape.setFillColor(null);
                                     break;
                                 default:
@@ -712,6 +719,22 @@ public final class clsUtility {
                                     shape.setFillColor(tg.get_FillColor());
                                     break;
                             }
+                        }
+                        switch(lineType)
+                        {
+                            case TacticalLines.BS_ELLIPSE:
+                            case TacticalLines.BS_RECTANGLE:
+                                //case TacticalLines.BBS_RECTANGLE:
+                                shape.set_Fillstyle(tg.get_FillStyle());
+                                shape.setFillColor(tg.get_FillColor());
+                                break;
+                            case TacticalLines.BBS_RECTANGLE:
+                            case TacticalLines.PBS_RECTANGLE:
+                            case TacticalLines.PBS_SQUARE:
+                                shape.setFillColor(null);
+                                break;
+                            default:
+                                break;
                         }
                     }
                     break;
@@ -741,6 +764,7 @@ public final class clsUtility {
         {
             switch(linetype)
             {
+                case TacticalLines.BS_LINE:
                 case TacticalLines.PAA_RECTANGULAR:
                 case TacticalLines.RECTANGULAR_TARGET:
                 case TacticalLines.CFL:
@@ -1026,6 +1050,11 @@ public final class clsUtility {
                 if(lineType==TacticalLines.AIRFIELD)
                     if(j==1)
                         shape.setFillColor(null);
+                //diagnostic
+                if(lineType==TacticalLines.BBS_POINT)
+                    if(j==0)
+                        shape.setLineColor(null);
+                //end section
 
                 shapeType = shape.getShapeType();
 
@@ -1083,10 +1112,15 @@ public final class clsUtility {
                 case TacticalLines.LAUNCH_AREA:
                 case TacticalLines.DEFENDED_AREA_CIRCULAR:
                 case TacticalLines.SHIP_AOI_CIRCULAR:
+                case TacticalLines.PBS_ELLIPSE:
                 case TacticalLines.RECTANGULAR:
                 case TacticalLines.CUED_ACQUISITION:
+                case TacticalLines.PBS_RECTANGLE:
+                case TacticalLines.PBS_SQUARE:
                 case TacticalLines.CIRCULAR:
+                case TacticalLines.PBS_CIRCLE:
                 case TacticalLines.BDZ:
+                case TacticalLines.BBS_POINT:
                 case TacticalLines.FSA_CIRCULAR:
                 case TacticalLines.NOTACK:
                 case TacticalLines.FFA_CIRCULAR:
@@ -1433,6 +1467,7 @@ public final class clsUtility {
                 case TacticalLines.DOUBLEA:
                 case TacticalLines.LWFENCE:
                 case TacticalLines.HWFENCE:
+                case TacticalLines.BBS_LINE:
                 case TacticalLines.SINGLEC:
                 case TacticalLines.DOUBLEC:
                 case TacticalLines.TRIPLE:
@@ -1790,6 +1825,17 @@ public final class clsUtility {
      */
     public static boolean isAutoshape(TGLight tg) {
         try {
+            switch(tg.get_LineType())
+            {
+                case TacticalLines.BBS_RECTANGLE:
+                case TacticalLines.BS_RECTANGLE:
+                case TacticalLines.BS_ELLIPSE:
+                case TacticalLines.PBS_CIRCLE:
+                case TacticalLines.BS_CROSS:
+                case TacticalLines.BS_BBOX:
+                case TacticalLines.BBS_POINT:
+                    return true;
+            }
             MSInfo msInfo = MSLookup.getInstance().getMSLInfo(tg.get_SymbolId());
             if (msInfo == null || IsChange1Area(tg.get_LineType())) {
                 return false;
@@ -2138,6 +2184,7 @@ public final class clsUtility {
                 case TacticalLines.DOUBLEA:
                 case TacticalLines.LWFENCE:
                 case TacticalLines.HWFENCE:
+                case TacticalLines.BBS_LINE:
                 case TacticalLines.SINGLEC:
                 case TacticalLines.DOUBLEC:
                 case TacticalLines.TRIPLE:

--- a/renderer/src/main/java/armyc2/c5isr/RenderMultipoints/clsRenderer.java
+++ b/renderer/src/main/java/armyc2/c5isr/RenderMultipoints/clsRenderer.java
@@ -100,6 +100,336 @@ public final class clsRenderer {
     }
 
     /**
+     * Build a tactical graphic object from the client MilStdSymbol
+     *
+     * @param milStd MilstdSymbol object
+     * @param converter geographic to pixels converter
+     * @param lineType {@link armyc2.c5isr.JavaLineArray.BasicShapes}
+     * @return tactical graphic
+     */
+    public static TGLight createTGLightFromMilStdSymbolBasicShape(MilStdSymbol milStd,
+                                                                  IPointConversion converter,
+                                                                  int lineType) {
+        TGLight tg = new TGLight();
+        try {
+            boolean useLineInterpolation = milStd.getUseLineInterpolation();
+            tg.set_UseLineInterpolation(useLineInterpolation);
+            tg.set_LineType(lineType);
+            String status = tg.get_Status();
+            tg.set_VisibleModifiers(true);
+            //set tg latlongs and pixels
+            setClientCoords(milStd, tg);
+            //build tg.Pixels
+            tg.Pixels = clsUtility.LatLongToPixels(tg.LatLongs, converter);
+            //tg.set_Font(new Font("Arial", Font.PLAIN, 12));
+            RendererSettings r = RendererSettings.getInstance();
+            int type = r.getMPLabelFontType();
+            String name = r.getMPLabelFontName();
+            int sz = r.getMPLabelFontSize();
+            Font font = new Font(name, type, sz);
+            tg.set_Font(font);
+            tg.set_FillColor(milStd.getFillColor());
+            tg.set_LineColor(milStd.getLineColor());
+            tg.set_LineThickness(milStd.getLineWidth());
+            tg.set_TexturePaint(milStd.getFillStyle());
+            tg.set_Fillstyle(milStd.getPatternFillType());
+            tg.set_patternScale(milStd.getPatternScale());
+
+            tg.set_IconSize(milStd.getUnitSize());
+            tg.set_KeepUnitRatio(milStd.getKeepUnitRatio());
+
+            tg.set_FontBackColor(Color.WHITE);
+            tg.set_TextColor(milStd.getTextColor());
+            if (milStd.getModifier(Modifiers.W_DTG_1) != null) {
+                tg.set_DTG(milStd.getModifier(Modifiers.W_DTG_1));
+            }
+            if (milStd.getModifier(Modifiers.W1_DTG_2) != null) {
+                tg.set_DTG1(milStd.getModifier(Modifiers.W1_DTG_2));
+            }
+            if (milStd.getModifier(Modifiers.H_ADDITIONAL_INFO_1) != null) {
+                tg.set_H(milStd.getModifier(Modifiers.H_ADDITIONAL_INFO_1));
+            }
+            if (milStd.getModifier(Modifiers.H1_ADDITIONAL_INFO_2) != null) {
+                tg.set_H1(milStd.getModifier(Modifiers.H1_ADDITIONAL_INFO_2));
+            }
+            if (milStd.getModifier(Modifiers.H2_ADDITIONAL_INFO_3) != null) {
+                tg.set_H2(milStd.getModifier(Modifiers.H2_ADDITIONAL_INFO_3));
+            }
+            if (milStd.getModifier(Modifiers.T_UNIQUE_DESIGNATION_1) != null) {
+                tg.set_Name(milStd.getModifier(Modifiers.T_UNIQUE_DESIGNATION_1));
+            }
+            if (milStd.getModifier(Modifiers.T1_UNIQUE_DESIGNATION_2) != null) {
+                tg.set_T1(milStd.getModifier(Modifiers.T1_UNIQUE_DESIGNATION_2));
+            }
+            if (milStd.getModifier(Modifiers.V_EQUIP_TYPE) != null) {
+                tg.set_V(milStd.getModifier(Modifiers.V_EQUIP_TYPE));
+            }
+            if (milStd.getModifier(Modifiers.AS_COUNTRY) != null) {
+                tg.set_AS(milStd.getModifier(Modifiers.AS_COUNTRY));
+            }
+            if (milStd.getModifier(Modifiers.AP_TARGET_NUMBER) != null) {
+                tg.set_AP(milStd.getModifier(Modifiers.AP_TARGET_NUMBER));
+            }
+            if (milStd.getModifier(Modifiers.Y_LOCATION) != null) {
+                tg.set_Location(milStd.getModifier(Modifiers.Y_LOCATION));
+            }
+            if (milStd.getModifier(Modifiers.N_HOSTILE) != null) {
+                tg.set_N(milStd.getModifier(Modifiers.N_HOSTILE));
+            }
+            tg.set_UseDashArray(milStd.getUseDashArray());
+            tg.set_UseHatchFill(milStd.getUseFillPattern());
+            //tg.set_UsePatternFill(milStd.getUseFillPattern());
+            tg.set_HideOptionalLabels(milStd.getHideOptionalLabels());
+            boolean isClosedArea = armyc2.c5isr.JavaTacticalRenderer.clsUtility.isClosedPolygon(lineType);
+
+         if (isClosedArea) {
+                armyc2.c5isr.JavaTacticalRenderer.clsUtility.ClosePolygon(tg.Pixels);
+                armyc2.c5isr.JavaTacticalRenderer.clsUtility.ClosePolygon(tg.LatLongs);
+            }
+
+            String strXAlt = "";
+            //construct the H1 and H2 modifiers for sector from the mss AM, AN, and X arraylists
+            if (lineType == TacticalLines.BS_ELLIPSE) {
+                ArrayList<Double> AM = milStd.getModifiers_AM_AN_X(Modifiers.AM_DISTANCE);
+                ArrayList<Double> AN = milStd.getModifiers_AM_AN_X(Modifiers.AN_AZIMUTH);
+                //ensure array length 3
+                double r2=0;
+                double b=0;
+                if(AM.size()==1)
+                {
+                    r2=AM.get(0);
+                    AM.add(r2);
+                    AM.add(0d);
+                }
+                else if(AM.size()==2)
+                {
+                    r2=AM.get(0);
+                    b=AM.get(1);
+                    AM.set(1, r2);
+                    AM.add(b);
+                }
+                if (AN == null) {
+                    AN = new ArrayList<Double>();
+                }
+                if (AN.size() < 1) {
+                    AN.add(new Double(0));
+                }
+                if (AM != null && AM.size() >= 2 && AN != null && AN.size() >= 1) {
+                    POINT2 ptAzimuth = new POINT2(0, 0);
+                    ptAzimuth.x = AN.get(0);
+                    POINT2 ptCenter = tg.Pixels.get(0);
+                    POINT2 pt0 = mdlGeodesic.geodesic_coordinate(tg.LatLongs.get(0), AM.get(0), 90);//semi-major axis
+                    POINT2 pt1 = mdlGeodesic.geodesic_coordinate(tg.LatLongs.get(0), AM.get(1), 0);//semi-minor axis
+                    Point2D pt02d = new Point2D.Double(pt0.x, pt0.y);
+                    Point2D pt12d = new Point2D.Double(pt1.x, pt1.y);
+                    pt02d = converter.GeoToPixels(pt02d);
+                    pt12d = converter.GeoToPixels(pt12d);
+                    pt0 = new POINT2(pt02d.getX(), pt02d.getY());
+                    pt1 = new POINT2(pt12d.getX(), pt12d.getY());
+                    tg.Pixels = new ArrayList<POINT2>();
+                    tg.Pixels.add(ptCenter);
+                    tg.Pixels.add(pt0);
+                    tg.Pixels.add(pt1);
+                    tg.Pixels.add(ptAzimuth);
+                }
+                if(AM != null && AM.size()>2)
+                {
+                    //use AM[2] for the buffer, so PBS_CIRCLE requires AM size 3 like PBS_ELLIPSE to use a buffer
+                    double dist=AM.get(2);
+                    POINT2 pt0=mdlGeodesic.geodesic_coordinate(tg.LatLongs.get(0), dist, 45);   //azimuth 45 is arbitrary
+                    Point2D pt02d = new Point2D.Double(tg.LatLongs.get(0).x,tg.LatLongs.get(0).y);
+                    Point2D pt12d = new Point2D.Double(pt0.x, pt0.y);
+                    pt02d = converter.GeoToPixels(pt02d);
+                    pt12d = converter.GeoToPixels(pt12d);
+                    pt0=new POINT2(pt02d.getX(),pt02d.getY());
+                    POINT2 pt1=new POINT2(pt12d.getX(),pt12d.getY());
+                    dist=lineutility.CalcDistanceDouble(pt0, pt1);
+                    //arraysupport will use line style to create the buffer shape
+                    tg.Pixels.get(0).style=(int)dist;
+                }
+            }
+            int j = 0;
+            if (lineType == TacticalLines.BBS_RECTANGLE || lineType == TacticalLines.BS_BBOX) {
+                double minLat = tg.LatLongs.get(0).y;
+                double maxLat = tg.LatLongs.get(0).y;
+                double minLong = tg.LatLongs.get(0).x;
+                double maxLong = tg.LatLongs.get(0).x;
+                for (j = 1; j < tg.LatLongs.size(); j++) {
+                    if (tg.LatLongs.get(j).x < minLong) {
+                        minLong = tg.LatLongs.get(j).x;
+                    }
+                    if (tg.LatLongs.get(j).x > maxLong) {
+                        maxLong = tg.LatLongs.get(j).x;
+                    }
+                    if (tg.LatLongs.get(j).y < minLat) {
+                        minLat = tg.LatLongs.get(j).y;
+                    }
+                    if (tg.LatLongs.get(j).y > maxLat) {
+                        maxLat = tg.LatLongs.get(j).y;
+                    }
+                }
+                tg.LatLongs = new ArrayList();
+                tg.LatLongs.add(new POINT2(minLong, maxLat));
+                tg.LatLongs.add(new POINT2(maxLong, maxLat));
+                tg.LatLongs.add(new POINT2(maxLong, minLat));
+                tg.LatLongs.add(new POINT2(minLong, minLat));
+                if (lineType == TacticalLines.BS_BBOX) {
+                    tg.LatLongs.add(new POINT2(minLong, maxLat));
+                }
+                tg.Pixels = clsUtility.LatLongToPixels(tg.LatLongs, converter);
+            }
+            //these have a buffer value in meters which we'll stuff tg.H2
+            //and use the style member of tg.Pixels to stuff the buffer width in pixels
+            switch (lineType) {
+                case TacticalLines.BBS_AREA:
+                case TacticalLines.BBS_LINE:
+                case TacticalLines.BBS_RECTANGLE:
+                    String H2 = null;
+                    double dist = 0;
+                    POINT2 pt0;
+                    POINT2 pt1;//45 is arbitrary
+                    ArrayList<Double> AM = milStd.getModifiers_AM_AN_X(Modifiers.AM_DISTANCE);
+                    if (AM != null && AM.size() > 0) {
+                        H2 = AM.get(0).toString();
+                        tg.set_H2(H2);
+                    }
+                    if (H2 != null && !H2.isEmpty()) {
+                        for (j = 0; j < tg.LatLongs.size(); j++) {
+                            if (tg.LatLongs.size() > j) {
+                                if (!Double.isNaN(Double.parseDouble(H2))) {
+                                    if (j == 0) {
+                                        dist = Double.parseDouble(H2);
+                                        pt0 = new POINT2(tg.LatLongs.get(0));
+                                        pt1 = mdlGeodesic.geodesic_coordinate(pt0, dist, 45);//45 is arbitrary
+                                        Point2D pt02d = new Point2D.Double(pt0.x, pt0.y);
+                                        Point2D pt12d = new Point2D.Double(pt1.x, pt1.y);
+                                        pt02d = converter.GeoToPixels(pt02d);
+                                        pt12d = converter.GeoToPixels(pt12d);
+                                        pt0.x = pt02d.getX();
+                                        pt0.y = pt02d.getY();
+                                        pt1.x = pt12d.getX();
+                                        pt1.y = pt12d.getY();
+                                        dist = lineutility.CalcDistanceDouble(pt0, pt1);
+                                    }
+                                    tg.Pixels.get(j).style = Math.round((float) dist);
+                                } else {
+                                    tg.Pixels.get(j).style = 0;
+                                }
+                            }
+                        }
+                    }
+                    break;
+                default:
+                    break;
+            }
+            if (lineType == TacticalLines.PBS_ELLIPSE) //geo ellipse
+            {
+                ArrayList<Double> AM = milStd.getModifiers_AM_AN_X(Modifiers.AM_DISTANCE);
+                ArrayList<Double> AN = milStd.getModifiers_AM_AN_X(Modifiers.AN_AZIMUTH);
+                if (AM != null && AM.size() > 1) {
+                    String strAM = AM.get(0).toString(); // major axis
+                    tg.set_AM(strAM);
+                    String strAM1 = AM.get(1).toString(); // minor axis
+                    tg.set_AM1(strAM1);
+                }
+                if (AN != null && AN.size() > 0) {
+                    String strAN = AN.get(0).toString(); // rotation
+                    tg.set_AN(strAN);
+                }
+            }
+            switch (lineType) {
+                case TacticalLines.BBS_AREA:
+                case TacticalLines.BBS_LINE:
+                case TacticalLines.BBS_POINT:
+                case TacticalLines.BBS_RECTANGLE:
+                    if (tg.get_FillColor() == null) {
+                        tg.set_FillColor(Color.LIGHT_GRAY);
+                    }
+                    break;
+                default:
+                    break;
+            }
+            switch (lineType) {
+                case TacticalLines.PBS_CIRCLE:
+                case TacticalLines.BBS_POINT:
+                    ArrayList<Double> AM = milStd.getModifiers_AM_AN_X(Modifiers.AM_DISTANCE);
+                    if (AM != null && AM.size() > 0) {
+                        String strAM = Double.toString(AM.get(0));
+                        //set width for rectangles or radius for circles
+                        tg.set_AM(strAM);
+                    } else if (lineType == TacticalLines.BBS_POINT && tg.LatLongs.size() > 1) {
+                        double dist = mdlGeodesic.geodesic_distance(tg.LatLongs.get(0), tg.LatLongs.get(1), null, null);
+                        String strT1 = Double.toString(dist);
+                        tg.set_T1(strT1);
+                    }
+                    break;
+                default:
+                    break;
+            }
+            if (lineType == TacticalLines.PBS_RECTANGLE || lineType == TacticalLines.PBS_SQUARE) {
+                ArrayList<Double> AM = milStd.getModifiers_AM_AN_X(Modifiers.AM_DISTANCE);
+                ArrayList<Double> AN = milStd.getModifiers_AM_AN_X(Modifiers.AN_AZIMUTH);
+                if (lineType == TacticalLines.PBS_SQUARE) //for square
+                {
+                    double r2=AM.get(0);
+                    double b=0;
+                    if(AM.size()==1)
+                    {
+                        AM.add(r2);
+                        AM.add(b);
+                    }
+                    else if(AM.size()==2)
+                    {
+                        b=AM.get(1);
+                        AM.set(1,r2);
+                        AM.add(b);
+                    }
+                    else if(AM.size()>2)
+                        AM.set(1, r2);
+                }
+                //if all these conditions are not met we do not want to set any tg modifiers
+                if (lineType == TacticalLines.PBS_SQUARE) //square
+                {
+                    double am0 = AM.get(0);
+                    if (AM.size() == 1) {
+                        AM.add(am0);
+                    } else if (AM.size() >= 2) {
+                        AM.set(1, am0);
+                    }
+                }
+                if (AN == null) {
+                    AN = new ArrayList<>();
+                }
+                if (AN.isEmpty()) {
+                    AN.add(0d);
+                }
+
+                if (AM != null && AM.size() > 1) {
+                    String strAM = Double.toString(AM.get(0));    //width
+                    String strAM1 = Double.toString(AM.get(1));     //length
+                    //set width and length in meters for rectangular target
+                    tg.set_AM(strAM);
+                    tg.set_AM1(strAM1);
+                    //set attitude in degrees
+                    String strAN = Double.toString(AN.get(0));
+                    tg.set_AN(strAN);
+                }
+                /*
+                if(AM.size()>2)
+                {
+                    String strH1 = Double.toString(AM.get(2));     //buffer size
+                    tg.set_H1(strH1);
+                }
+                 */
+            }
+        } catch (Exception exc) {
+            ErrorLogger.LogException("clsRenderer", "createTGLightFromBasicMilStdSymbol",
+                    new RendererException("Failed to build multipoint TG for " + lineType, exc));
+        }
+        return tg;
+    }
+
+    /**
      * Create MilStdSymbol from tactical graphic
      *
      * @deprecated
@@ -1408,6 +1738,35 @@ public final class clsRenderer {
         } catch (Exception exc) {
             ErrorLogger.LogException(_className, "render_Shape",
                     new RendererException("Failed inside render_Shape", exc));
+
+        }
+    }
+
+    private static void resolvePostClippedShapes(TGLight tg, ArrayList<Shape2> shapes) {
+        try {
+            //resolve the PBS and BBS shape properties after the post clip, regardless whether they were clipped
+            switch (tg.get_LineType()) {
+                case TacticalLines.BBS_RECTANGLE:
+                case TacticalLines.BBS_POINT:
+                case TacticalLines.BBS_LINE:
+                case TacticalLines.BBS_AREA:
+                case TacticalLines.PBS_RECTANGLE:
+                case TacticalLines.PBS_SQUARE:
+                    break;
+                default:
+                    return;
+            }
+            Color fillColor = tg.get_FillColor();
+            shapes.get(0).setFillColor(fillColor);
+            shapes.get(1).setFillColor(null);
+            int fillStyle = tg.get_FillStyle();
+            shapes.get(0).set_Fillstyle(0);
+            shapes.get(1).set_Fillstyle(fillStyle);
+            return;
+
+        } catch (Exception exc) {
+            ErrorLogger.LogException(_className, "resolvePostClippedShapes",
+                    new RendererException("Failed inside resolvePostClippedShapes", exc));
 
         }
     }

--- a/renderer/src/main/java/armyc2/c5isr/RenderMultipoints/clsRenderer.java
+++ b/renderer/src/main/java/armyc2/c5isr/RenderMultipoints/clsRenderer.java
@@ -1282,6 +1282,7 @@ public final class clsRenderer {
             } else if (clsUtilityCPOF.canClipPoints(tg) == false && clipPoints != null) {
                 shapes = clsUtilityCPOF.postClipShapes(tg, shapes, clipPoints);
             }
+            resolvePostClippedShapes(tg,shapes);
             //returns early if textSpecs are null
             //currently the client is ignoring these
             if (modifierShapeInfos != null) {

--- a/renderer/src/main/java/armyc2/c5isr/RenderMultipoints/clsRenderer2.java
+++ b/renderer/src/main/java/armyc2/c5isr/RenderMultipoints/clsRenderer2.java
@@ -299,6 +299,7 @@ public final class clsRenderer2 {
             {
                 //this will help with click-drag mode
                 if(tg.Pixels.size()<2)
+                    if(lineType != TacticalLines.BS_CROSS)
                         return null;
                 
                 if (CELineArray.CIsChannel(lineType) == 0)

--- a/renderer/src/main/java/armyc2/c5isr/RenderMultipoints/clsUtility.java
+++ b/renderer/src/main/java/armyc2/c5isr/RenderMultipoints/clsUtility.java
@@ -68,7 +68,15 @@ public final class clsUtility {
             {
                 if(armyc2.c5isr.JavaTacticalRenderer.clsUtility.IsChange1Area(lineType)==false)
                 {
-                    return;
+                    switch(lineType)
+                    {
+                        case TacticalLines.BBS_AREA:
+                        case TacticalLines.BBS_LINE:
+                        case TacticalLines.BBS_RECTANGLE:
+                            break;
+                        default:
+                            return;
+                    }
                 }
             }
 

--- a/renderer/src/main/java/armyc2/c5isr/RenderMultipoints/clsUtilityCPOF.java
+++ b/renderer/src/main/java/armyc2/c5isr/RenderMultipoints/clsUtilityCPOF.java
@@ -93,7 +93,9 @@ public final class clsUtilityCPOF {
             length.value = new double[1];
             switch (lineType) {
                 case TacticalLines.CIRCULAR:
+                case TacticalLines.PBS_CIRCLE:
                 case TacticalLines.BDZ:
+                case TacticalLines.BBS_POINT:
                 case TacticalLines.FSA_CIRCULAR:
                 case TacticalLines.NOTACK:
                 case TacticalLines.FFA_CIRCULAR:
@@ -119,6 +121,7 @@ public final class clsUtilityCPOF {
                 case TacticalLines.LAUNCH_AREA:
                 case TacticalLines.DEFENDED_AREA_CIRCULAR:
                 case TacticalLines.SHIP_AOI_CIRCULAR:
+                case TacticalLines.PBS_ELLIPSE:
                     //minor radius in meters
                     if (SymbolUtilities.isNumber(tg.get_AM1())) {
                         length.value[0] = Double.parseDouble(tg.get_AM1());
@@ -144,6 +147,20 @@ public final class clsUtilityCPOF {
                     //so we must multiply by 360/6400 to convert to degrees                    
                     if (SymbolUtilities.isNumber(tg.get_AN())) {
                         attitude.value[0] = Double.parseDouble(tg.get_AN()) * (360d / 6400d);
+                    }
+                    break;
+                case TacticalLines.PBS_RECTANGLE:
+                case TacticalLines.PBS_SQUARE:
+                    if (SymbolUtilities.isNumber(tg.get_AM1())) {
+                        length.value[0] = Double.parseDouble(tg.get_AM1());
+                    }
+                    if (SymbolUtilities.isNumber(tg.get_AM())) {
+                        width.value[0] = Double.parseDouble(tg.get_AM());
+                    }
+                    //assume that attitude was passed in mils
+                    //so we must multiply by 360/6400 to convert to degrees                    
+                    if (SymbolUtilities.isNumber(tg.get_AN())) {
+                        attitude.value[0] = Double.parseDouble(tg.get_AN());
                     }
                     break;
                 case TacticalLines.CUED_ACQUISITION:
@@ -308,6 +325,7 @@ public final class clsUtilityCPOF {
                 case TacticalLines.LAUNCH_AREA:
                 case TacticalLines.DEFENDED_AREA_CIRCULAR:
                 case TacticalLines.SHIP_AOI_CIRCULAR:
+                case TacticalLines.PBS_ELLIPSE:
                     POINT2[] ellipsePts = mdlGeodesic.getGeoEllipse(pt0, width.value[0], length.value[0], attitude.value[0]);
                     for (j = 0; j < ellipsePts.length; j++) //was 103
                     {
@@ -421,6 +439,8 @@ public final class clsUtilityCPOF {
                     tg.Pixels.add(ptTemp);
                     break;
                 case TacticalLines.RECTANGULAR:
+                case TacticalLines.PBS_RECTANGLE:
+                case TacticalLines.PBS_SQUARE:
                 case TacticalLines.CUED_ACQUISITION:
                     //AFATDS swap length and width
                     //comment next three lines to render per Mil-Std-2525
@@ -459,7 +479,9 @@ public final class clsUtilityCPOF {
                     tg.Pixels.add(new POINT2(tg.Pixels.get(0).x, tg.Pixels.get(0).y));
                     break;
                 case TacticalLines.CIRCULAR:
+                case TacticalLines.PBS_CIRCLE:
                 case TacticalLines.BDZ:
+                case TacticalLines.BBS_POINT:
                 case TacticalLines.FSA_CIRCULAR:
                 case TacticalLines.NOTACK:
                 case TacticalLines.ACA_CIRCULAR:
@@ -552,6 +574,42 @@ public final class clsUtilityCPOF {
                 //load left and right shapes into shapes
                 shapes.addAll(shapesLeft);
                 shapes.addAll(shapesRight);
+            }
+            if (lineType == TacticalLines.BBS_POINT) {
+                Shape2 shape = new Shape2(Shape2.SHAPE_TYPE_POLYLINE);
+                shape.moveTo(ptCenter);
+                //ptCenter.x+=1;
+                ptCenter.y += 1;
+                shape.lineTo(ptCenter);
+                shapes.add(shape);
+            }
+            if (lineType == TacticalLines.PBS_RECTANGLE || lineType == TacticalLines.PBS_SQUARE)
+            {
+                double dist = radius.value[0];//Double.parseDouble(strH1);
+                pt0 = new POINT2(tg.LatLongs.get(0));
+                pt1 = mdlGeodesic.geodesic_coordinate(pt0, dist, 45);//45 is arbitrary
+                Point2D pt02d = new Point2D.Double(pt0.x, pt0.y);
+                Point2D pt12d = new Point2D.Double(pt1.x, pt1.y);
+                pt02d = converter.GeoToPixels(pt02d);
+                pt12d = converter.GeoToPixels(pt12d);
+                pt0.x = pt02d.getX();
+                pt0.y = pt02d.getY();
+                pt1.x = pt12d.getX();
+                pt1.y = pt12d.getY();
+                dist = lineutility.CalcDistanceDouble(pt0, pt1);    //pixels distance
+                //tg.Pixels.get(0).style=(int)dist;
+                ArrayList<POINT2> tempPixels = new ArrayList();
+                tempPixels.addAll((ArrayList) tg.Pixels);
+                POINT2[]pts=tempPixels.toArray(new POINT2[tempPixels.size()]);
+                pts[0].style=(int)dist;
+                lineutility.getExteriorPoints(pts, pts.length, lineType, false);
+                tg.Pixels.clear();
+                for(j=0;j<pts.length;j++)
+                    tg.Pixels.add(new POINT2(pts[j].x,pts[j].y));
+
+                Change1PixelsToShapes(tg, shapes, true);
+                //reuse the original pixels for the subsequent call to AddModifier2
+                tg.Pixels = tempPixels;
             }
             return true;
         } catch (Exception exc) {
@@ -1034,6 +1092,9 @@ public final class clsUtilityCPOF {
             //do not clear pixel style for the air corridors because
             //arraysupport is using linestyle for these to set the segment width         
             switch (tg.get_LineType()) {
+                case TacticalLines.BBS_AREA:
+                case TacticalLines.BBS_LINE:
+                case TacticalLines.BBS_RECTANGLE:
                 case TacticalLines.SC:
                 case TacticalLines.MRR:
                 case TacticalLines.SL:
@@ -1041,6 +1102,7 @@ public final class clsUtilityCPOF {
                 case TacticalLines.LLTR:
                 case TacticalLines.AC:
                 case TacticalLines.SAAFR:
+                case TacticalLines.BS_ELLIPSE:
                     return;
                 default:
                     break;
@@ -1247,6 +1309,8 @@ public final class clsUtilityCPOF {
                 case TacticalLines.JTAA:
                 case TacticalLines.SAA:
                 case TacticalLines.SGAA:
+                case TacticalLines.BS_AREA:
+                case TacticalLines.BS_LINE:
                 case TacticalLines.ASSY:
                 case TacticalLines.EA:
                 case TacticalLines.FORT_REVD:
@@ -1877,6 +1941,9 @@ public final class clsUtilityCPOF {
             }
             //do not pre-segment the autoshapes
             if (clsUtility.isAutoshape(tg)) {
+                return false;
+            }
+            if (SymbolUtilities.isBasicShape(linetype)) {
                 return false;
             }
             //temporarily do not pre-segment the channel types.

--- a/renderer/src/main/java/armyc2/c5isr/RenderMultipoints/clsUtilityGE.java
+++ b/renderer/src/main/java/armyc2/c5isr/RenderMultipoints/clsUtilityGE.java
@@ -315,6 +315,9 @@ public final class clsUtilityGE {
 
             switch(linetype)
             {
+                case TacticalLines.BBS_AREA:
+                case TacticalLines.BBS_RECTANGLE:
+
                 case TacticalLines.CATK:
                 case TacticalLines.CATKBYFIRE:
                 case TacticalLines.AIRAOA:

--- a/renderer/src/main/java/armyc2/c5isr/renderer/utilities/SymbolUtilities.java
+++ b/renderer/src/main/java/armyc2/c5isr/renderer/utilities/SymbolUtilities.java
@@ -11,6 +11,8 @@ import java.util.Locale;
 import java.util.TimeZone;
 import java.util.regex.Pattern;
 
+import armyc2.c5isr.JavaLineArray.TacticalLines;
+
 /**
  * Has various utility functions for prcessing the symbol code.
  * See {@link SymbolID} for additional functions related to parsing the symbol code.
@@ -1770,4 +1772,29 @@ public class SymbolUtilities {
         return rw;
     }
 
+    /**
+     * @param linetype the line type
+     * @return true if the line is a basic shape
+     */
+    public static boolean isBasicShape(int linetype) {
+        switch (linetype) {
+            case TacticalLines.BS_AREA:
+            case TacticalLines.BS_LINE:
+            case TacticalLines.BS_CROSS:
+            case TacticalLines.BS_ELLIPSE:
+            case TacticalLines.PBS_ELLIPSE:
+            case TacticalLines.PBS_CIRCLE:
+            case TacticalLines.PBS_SQUARE:
+            case TacticalLines.PBS_RECTANGLE:
+            case TacticalLines.BS_RECTANGLE:
+            case TacticalLines.BBS_AREA:
+            case TacticalLines.BBS_LINE:
+            case TacticalLines.BBS_POINT:
+            case TacticalLines.BBS_RECTANGLE:
+            case TacticalLines.BS_BBOX:
+                return true;
+            default:
+                return false;
+        }
+    }
 }

--- a/renderer/src/main/java/armyc2/c5isr/web/render/MultiPointHandler.java
+++ b/renderer/src/main/java/armyc2/c5isr/web/render/MultiPointHandler.java
@@ -3044,4 +3044,571 @@ public class MultiPointHandler {
             return "true";
         }
     }
+
+    /**
+     *
+     * @param id
+     * @param name
+     * @param description
+     * @param basicShapeType
+     * @param controlPoints
+     * @param scale
+     * @param bbox
+     * @param symbolModifiers
+     * @param symbolAttributes
+     * @return
+     */
+    public static MilStdSymbol RenderBasicShapeAsMilStdSymbol(String id,
+                                                          String name,
+                                                          String description,
+                                                          int basicShapeType,
+                                                          String controlPoints,
+                                                          Double scale,
+                                                          String bbox,
+                                                          Map<String,String> symbolModifiers,
+                                                          Map<String,String> symbolAttributes)
+    {
+        MilStdSymbol mSymbol = null;
+        boolean normalize = true;
+        Double controlLat = 0.0;
+        Double controlLong = 0.0;
+        //String jsonContent = "";
+
+        Rectangle rect = null;
+
+        //for symbol & line fill
+        ArrayList<POINT2> tgPoints = null;
+
+        String[] coordinates = controlPoints.split(" ");
+        ArrayList<ShapeInfo> shapes = null;//new ArrayList<ShapeInfo>();
+        ArrayList<ShapeInfo> modifiers = null;//new ArrayList<ShapeInfo>();
+        //ArrayList<Point2D> pixels = new ArrayList<Point2D>();
+        ArrayList<Point2D> geoCoords = new ArrayList<Point2D>();
+        int len = coordinates.length;
+
+        IPointConversion ipc = null;
+
+        //Deutch moved section 6-29-11
+        Double left = 0.0;
+        Double right = 0.0;
+        Double top = 0.0;
+        Double bottom = 0.0;
+        Point2D temp = null;
+        Point2D ptGeoUL = null;
+        int width = 0;
+        int height = 0;
+        int leftX = 0;
+        int topY = 0;
+        int bottomY = 0;
+        int rightX = 0;
+        int j = 0;
+        ArrayList<Point2D> bboxCoords = null;
+        if (bbox != null && bbox.equals("") == false) {
+            String[] bounds = null;
+            if (bbox.contains(" "))//trapezoid
+            {
+                bboxCoords = new ArrayList<Point2D>();
+                double x = 0;
+                double y = 0;
+                String[] coords = bbox.split(" ");
+                String[] arrCoord;
+                for (String coord : coords) {
+                    arrCoord = coord.split(",");
+                    x = Double.valueOf(arrCoord[0]);
+                    y = Double.valueOf(arrCoord[1]);
+                    bboxCoords.add(new Point2D.Double(x, y));
+                }
+                //use the upper left corner of the MBR containing geoCoords
+                //to set the converter
+                ptGeoUL = getGeoUL(bboxCoords);
+                left = ptGeoUL.getX();
+                top = ptGeoUL.getY();
+                ipc = new PointConverter(left, top, scale);
+                Point2D ptPixels = null;
+                Point2D ptGeo = null;
+                int n = bboxCoords.size();
+                //for (j = 0; j < bboxCoords.size(); j++)
+                for (j = 0; j < n; j++) {
+                    ptGeo = bboxCoords.get(j);
+                    ptPixels = ipc.GeoToPixels(ptGeo);
+                    x = ptPixels.getX();
+                    y = ptPixels.getY();
+                    if (x < 20) {
+                        x = 20;
+                    }
+                    if (y < 20) {
+                        y = 20;
+                    }
+                    ptPixels.setLocation(x, y);
+                    //end section
+                    bboxCoords.set(j, (Point2D) ptPixels);
+                }
+            } else//rectangle
+            {
+                bounds = bbox.split(",");
+                left = Double.valueOf(bounds[0]);
+                right = Double.valueOf(bounds[2]);
+                top = Double.valueOf(bounds[3]);
+                bottom = Double.valueOf(bounds[1]);
+                scale = getReasonableScale(bbox, scale);
+                ipc = new PointConverter(left, top, scale);
+            }
+
+            Point2D pt2d = null;
+            if (bboxCoords == null) {
+                pt2d = new Point2D.Double(left, top);
+                temp = ipc.GeoToPixels(pt2d);
+
+                leftX = (int) temp.getX();
+                topY = (int) temp.getY();
+
+                pt2d = new Point2D.Double(right, bottom);
+                temp = ipc.GeoToPixels(pt2d);
+
+                bottomY = (int) temp.getY();
+                rightX = (int) temp.getX();
+                //diagnostic clipping does not work for large scales
+//                if (scale > 10e6) {
+//                    //get widest point in the AOI
+//                    double midLat = 0;
+//                    if (bottom < 0 && top > 0) {
+//                        midLat = 0;
+//                    } else if (bottom < 0 && top < 0) {
+//                        midLat = top;
+//                    } else if (bottom > 0 && top > 0) {
+//                        midLat = bottom;
+//                    }
+//
+//                    temp = ipc.GeoToPixels(new Point2D.Double(right, midLat));
+//                    rightX = (int) temp.getX();
+//                }
+                //end section
+
+                width = (int) Math.abs(rightX - leftX);
+                height = (int) Math.abs(bottomY - topY);
+
+                if(width==0 || height==0)
+                    rect=null;
+                else
+                    rect = new Rectangle(leftX, topY, width, height);
+            }
+        } else {
+            rect = null;
+        }
+        //end section
+
+        for (int i = 0; i < len; i++) {
+            String[] coordPair = coordinates[i].split(",");
+            Double latitude = Double.valueOf(coordPair[1].trim());
+            Double longitude = Double.valueOf(coordPair[0].trim());
+            geoCoords.add(new Point2D.Double(longitude, latitude));
+        }
+        if (ipc == null) {
+            Point2D ptCoordsUL = getGeoUL(geoCoords);
+            ipc = new PointConverter(ptCoordsUL.getX(), ptCoordsUL.getY(), scale);
+        }
+        //if (crossesIDL(geoCoords) == true)
+//        if(Math.abs(right-left)>180)
+//        {
+//            normalize = true;
+//            ((PointConverter)ipc).set_normalize(true);
+//        }
+//        else {
+//            normalize = false;
+//            ((PointConverter)ipc).set_normalize(false);
+//        }
+
+        //seems to work ok at world view
+//        if (normalize) {
+//            NormalizeGECoordsToGEExtents(0, 360, geoCoords);
+//        }
+
+        //M. Deutch 10-3-11
+        //must shift the rect pixels to synch with the new ipc
+        //the old ipc was in synch with the bbox, so rect x,y was always 0,0
+        //the new ipc synchs with the upper left of the geocoords so the boox is shifted
+        //and therefore the clipping rectangle must shift by the delta x,y between
+        //the upper left corner of the original bbox and the upper left corner of the geocoords
+        ArrayList<Point2D> geoCoords2 = new ArrayList<Point2D>();
+        geoCoords2.add(new Point2D.Double(left, top));
+        geoCoords2.add(new Point2D.Double(right, bottom));
+
+//        if (normalize) {
+//            NormalizeGECoordsToGEExtents(0, 360, geoCoords2);
+//        }
+
+        //disable clipping
+        if (crossesIDL(geoCoords) == false) {
+            rect = null;
+            bboxCoords = null;
+        }
+
+        String symbolCode = "";
+        try {
+            String fillColor = null;
+            mSymbol = new MilStdSymbol(symbolCode, null, geoCoords, null);
+
+//            mSymbol.setUseDashArray(true);
+
+            if (symbolModifiers != null || symbolAttributes != null) {
+                populateModifiers(symbolModifiers, symbolAttributes, mSymbol);
+            } else {
+                mSymbol.setFillColor(null);
+            }
+
+            if (mSymbol.getFillColor() != null) {
+                Color fc = mSymbol.getFillColor();
+                //fillColor = Integer.toHexString(fc.getRGB());
+                fillColor = Integer.toHexString(fc.toARGB());
+            }
+
+            TGLight tg = clsRenderer.createTGLightFromMilStdSymbolBasicShape(mSymbol, ipc, basicShapeType);
+            ArrayList<ShapeInfo> shapeInfos = new ArrayList();
+            ArrayList<ShapeInfo> modifierShapeInfos = new ArrayList();
+            Object clipArea;
+            if (bboxCoords == null) {
+                clipArea = rect;
+            } else {
+                clipArea = bboxCoords;
+            }
+            if (clsRenderer.intersectsClipArea(tg, ipc, clipArea)) {
+                clsRenderer.render_GE(tg, shapeInfos, modifierShapeInfos, ipc, clipArea);
+            }
+            mSymbol.setSymbolShapes(shapeInfos);
+            mSymbol.setModifierShapes(modifierShapeInfos);
+            mSymbol.set_WasClipped(tg.get_WasClipped());
+            shapes = mSymbol.getSymbolShapes();
+            modifiers = mSymbol.getModifierShapes();
+
+            //convert points////////////////////////////////////////////////////
+            ArrayList<ArrayList<Point2D>> polylines = null;
+            ArrayList<ArrayList<Point2D>> newPolylines = null;
+            ArrayList<Point2D> newLine = null;
+            for (ShapeInfo shape : shapes) {
+                polylines = shape.getPolylines();
+                //System.out.println("pixel polylines: " + String.valueOf(polylines));
+                newPolylines = ConvertPolylinePixelsToCoords(polylines, ipc, normalize);
+                shape.setPolylines(newPolylines);
+            }
+
+            for (ShapeInfo label : modifiers) {
+                Point2D pixelCoord = label.getModifierPosition();
+                if (pixelCoord == null) {
+                    pixelCoord = label.getGlyphPosition();
+                }
+                Point2D geoCoord = ipc.PixelsToGeo(pixelCoord);
+
+                if (normalize) {
+                    geoCoord = NormalizeCoordToGECoord(geoCoord);
+                }
+
+                double latitude = geoCoord.getY();
+                double longitude = geoCoord.getX();
+                label.setModifierPosition(new Point2D.Double(longitude, latitude));
+
+            }
+
+            ////////////////////////////////////////////////////////////////////
+            mSymbol.setModifierShapes(modifiers);
+            mSymbol.setSymbolShapes(shapes);
+
+        } catch (Exception exc) {
+            System.out.println(exc.getMessage());
+            System.out.println("Symbol Code: " + symbolCode);
+            exc.printStackTrace();
+        }
+
+        boolean debug = false;
+        if (debug == true) {
+            System.out.println("Symbol Code: " + symbolCode);
+            System.out.println("Scale: " + scale);
+            System.out.println("BBOX: " + bbox);
+            if (controlPoints != null) {
+                System.out.println("Geo Points: " + controlPoints);
+            }
+            if (bbox != null) {
+                System.out.println("geo bounds: " + bbox);
+            }
+            if (rect != null) {
+                System.out.println("pixel bounds: " + rect.toString());
+            }
+        }
+
+        return mSymbol;
+
+    }
+
+    /**
+     *
+     * @param id - For the client to track the symbol, not related to rendering
+     * @param name - For the client to track the symbol, not related to rendering
+     * @param description - For the client to track the symbol, not related to rendering
+     * @param basicShapeType
+     * @param controlPoints
+     * @param scale
+     * @param bbox
+     * @param symbolModifiers keyed using constants from
+     * Modifiers. Pass in comma delimited String for modifiers with multiple
+     * values like AM, AN &amp; X
+     * @param symbolAttributes keyed using constants from
+     * MilStdAttributes. pass in double[] for AM, AN and X; Strings for the
+     * rest.
+     * @param format
+     * @return
+     */
+    public static String RenderBasicShape(String id,
+                                          String name,
+                                          String description,
+                                          int basicShapeType,
+                                          String controlPoints,
+                                          Double scale,
+                                          String bbox,
+                                          Map<String,String> symbolModifiers,
+                                          Map<String,String> symbolAttributes,
+                                          int format)//,
+    {
+        boolean normalize = true;
+        //Double controlLat = 0.0;
+        //Double controlLong = 0.0;
+        //Double metPerPix = GeoPixelConversion.metersPerPixel(scale);
+        //String bbox2=getBoundingRectangle(controlPoints,bbox);
+        StringBuilder jsonOutput = new StringBuilder();
+        String jsonContent = "";
+
+        Rectangle rect = null;
+        String[] coordinates = controlPoints.split(" ");
+        ArrayList<ShapeInfo> shapes = new ArrayList<ShapeInfo>();
+        ArrayList<ShapeInfo> modifiers = new ArrayList<ShapeInfo>();
+        //ArrayList<Point2D> pixels = new ArrayList<Point2D>();
+        ArrayList<Point2D> geoCoords = new ArrayList<Point2D>();
+        int len = coordinates.length;
+        //diagnostic create geoCoords here
+        Point2D coordsUL=null;
+        final String symbolCode = "";
+
+        for (int i = 0; i < len; i++)
+        {
+            String[] coordPair = coordinates[i].split(",");
+            Double latitude = Double.valueOf(coordPair[1].trim()).doubleValue();
+            Double longitude = Double.valueOf(coordPair[0].trim()).doubleValue();
+            geoCoords.add(new Point2D.Double(longitude, latitude));
+        }
+        ArrayList<POINT2> tgPoints = null;
+        IPointConversion ipc = null;
+
+        //Deutch moved section 6-29-11
+        Double left = 0.0;
+        Double right = 0.0;
+        Double top = 0.0;
+        Double bottom = 0.0;
+        Point2D temp = null;
+        Point2D ptGeoUL = null;
+        int width = 0;
+        int height = 0;
+        int leftX = 0;
+        int topY = 0;
+        int bottomY = 0;
+        int rightX = 0;
+        int j = 0;
+        ArrayList<Point2D> bboxCoords = null;
+        if (bbox != null && bbox.equals("") == false) {
+            String[] bounds = null;
+            if (bbox.contains(" "))//trapezoid
+            {
+                bboxCoords = new ArrayList<Point2D>();
+                double x = 0;
+                double y = 0;
+                String[] coords = bbox.split(" ");
+                String[] arrCoord;
+                for (String coord : coords) {
+                    arrCoord = coord.split(",");
+                    x = Double.valueOf(arrCoord[0]);
+                    y = Double.valueOf(arrCoord[1]);
+                    bboxCoords.add(new Point2D.Double(x, y));
+                }
+                //use the upper left corner of the MBR containing geoCoords
+                //to set the converter
+                ptGeoUL = getGeoUL(bboxCoords);
+                left = ptGeoUL.getX();
+                top = ptGeoUL.getY();
+                String bbox2=getBboxFromCoords(bboxCoords);
+                scale = getReasonableScale(bbox2, scale);
+                ipc = new PointConverter(left, top, scale);
+                Point2D ptPixels = null;
+                Point2D ptGeo = null;
+                int n = bboxCoords.size();
+                //for (j = 0; j < bboxCoords.size(); j++)
+                for (j = 0; j < n; j++) {
+                    ptGeo = bboxCoords.get(j);
+                    ptPixels = ipc.GeoToPixels(ptGeo);
+                    x = ptPixels.getX();
+                    y = ptPixels.getY();
+                    if (x < 20) {
+                        x = 20;
+                    }
+                    if (y < 20) {
+                        y = 20;
+                    }
+                    ptPixels.setLocation(x, y);
+                    //end section
+                    bboxCoords.set(j, (Point2D) ptPixels);
+                }
+            } else//rectangle
+            {
+                bounds = bbox.split(",");
+                left = Double.valueOf(bounds[0]);
+                right = Double.valueOf(bounds[2]);
+                top = Double.valueOf(bounds[3]);
+                bottom = Double.valueOf(bounds[1]);
+                scale = getReasonableScale(bbox, scale);
+                ipc = new PointConverter(left, top, scale);
+            }
+
+            Point2D pt2d = null;
+            if (bboxCoords == null) {
+                pt2d = new Point2D.Double(left, top);
+                temp = ipc.GeoToPixels(pt2d);
+
+                leftX = (int) temp.getX();
+                topY = (int) temp.getY();
+
+                pt2d = new Point2D.Double(right, bottom);
+                temp = ipc.GeoToPixels(pt2d);
+
+                bottomY = (int) temp.getY();
+                rightX = (int) temp.getX();
+
+                width = (int) Math.abs(rightX - leftX);
+                height = (int) Math.abs(bottomY - topY);
+
+                rect = new Rectangle(leftX, topY, width, height);
+            }
+        } else {
+            rect = null;
+        }
+
+        if (ipc == null) {
+            Point2D ptCoordsUL = getGeoUL(geoCoords);
+            ipc = new PointConverter(ptCoordsUL.getX(), ptCoordsUL.getY(), scale);
+        }
+
+        ArrayList<Point2D> geoCoords2 = new ArrayList<Point2D>();
+        geoCoords2.add(new Point2D.Double(left, top));
+        geoCoords2.add(new Point2D.Double(right, bottom));
+
+//        if (normalize) {
+//            NormalizeGECoordsToGEExtents(0, 360, geoCoords2);
+//        }
+
+        try {
+
+            //String fillColor = null;
+            MilStdSymbol mSymbol = new MilStdSymbol(symbolCode, null, geoCoords, null);
+
+            if (format == WebRenderer.OUTPUT_FORMAT_GEOSVG){
+                // Use dash array and hatch pattern fill for SVG output
+                symbolAttributes.put(MilStdAttributes.UseDashArray, "true");
+                symbolAttributes.put(MilStdAttributes.UsePatternFill, "true");
+            }
+
+            if (symbolModifiers != null || symbolAttributes != null) {
+                populateModifiers(symbolModifiers, symbolAttributes, mSymbol);
+            } else {
+                mSymbol.setFillColor(null);
+            }
+
+            TGLight tg = clsRenderer.createTGLightFromMilStdSymbolBasicShape(mSymbol, ipc, basicShapeType);
+            ArrayList<ShapeInfo> shapeInfos = new ArrayList();
+            ArrayList<ShapeInfo> modifierShapeInfos = new ArrayList();
+            Object clipArea;
+            if (bboxCoords == null) {
+                clipArea = rect;
+            } else {
+                clipArea = bboxCoords;
+            }
+            if (clsRenderer.intersectsClipArea(tg, ipc, clipArea)) {
+                clsRenderer.render_GE(tg, shapeInfos, modifierShapeInfos, ipc, clipArea);
+            }
+            mSymbol.setSymbolShapes(shapeInfos);
+            mSymbol.setModifierShapes(modifierShapeInfos);
+            mSymbol.set_WasClipped(tg.get_WasClipped());
+            shapes = mSymbol.getSymbolShapes();
+            modifiers = mSymbol.getModifierShapes();
+
+            if (format == WebRenderer.OUTPUT_FORMAT_JSON) {
+                jsonOutput.append("{\"type\":\"symbol\",");
+                jsonContent = JSONize(shapes, modifiers, ipc, true, normalize);
+                jsonOutput.append(jsonContent);
+                jsonOutput.append("}");
+            } else if (format == WebRenderer.OUTPUT_FORMAT_KML) {
+                Color textColor = mSymbol.getTextColor();
+                if(textColor==null)
+                    textColor=mSymbol.getLineColor();
+
+                jsonContent = KMLize(id, name, description, symbolCode, shapes, modifiers, ipc, normalize, textColor);
+                jsonOutput.append(jsonContent);
+            } else if (format == WebRenderer.OUTPUT_FORMAT_GEOJSON)
+            {
+                jsonOutput.append("{\"type\":\"FeatureCollection\",\"features\":");
+                jsonContent = GeoJSONize(shapes, modifiers, ipc, normalize, mSymbol.getTextColor(), mSymbol.getTextBackgroundColor());
+                jsonOutput.append(jsonContent);
+
+                //moving meta data properties to the last feature with no coords as feature collection doesn't allow properties
+                jsonOutput.replace(jsonOutput.toString().length()-1,jsonOutput.toString().length(),"" );
+                jsonOutput.append(",{\"type\": \"Feature\",\"geometry\": { \"type\": \"Polygon\",\"coordinates\": [ ]}");
+
+                jsonOutput.append(",\"properties\":{\"id\":\"");
+                jsonOutput.append(id);
+                jsonOutput.append("\",\"name\":\"");
+                jsonOutput.append(name);
+                jsonOutput.append("\",\"description\":\"");
+                jsonOutput.append(description);
+                jsonOutput.append("\",\"symbolID\":\"");
+                jsonOutput.append(symbolCode);
+                jsonOutput.append("\",\"wasClipped\":\"");
+                jsonOutput.append(String.valueOf(mSymbol.get_WasClipped()));
+                //jsonOutput.append("\"}}");
+
+                jsonOutput.append("\"}}]}");
+            } else if (format == WebRenderer.OUTPUT_FORMAT_GEOSVG) {
+                String textColor = mSymbol.getTextColor() != null ? RendererUtilities.colorToHexString(mSymbol.getTextColor(), false) : "";
+                String backgroundColor = mSymbol.getTextBackgroundColor() != null ? RendererUtilities.colorToHexString(mSymbol.getTextBackgroundColor(), false) : "";
+                //returns an svg with a geoTL and geoBR value to use to place the canvas on the map
+                jsonContent = MultiPointHandlerSVG.GeoSVGize(id, name, description, symbolCode, shapes, modifiers, ipc, normalize, textColor, backgroundColor, mSymbol.get_WasClipped());
+                jsonOutput.append(jsonContent);
+            }
+        } catch (Exception exc) {
+            String st = JavaRendererUtilities.getStackTrace(exc);
+            jsonOutput = new StringBuilder();
+            jsonOutput.append("{\"type\":\"error\",\"error\":\"There was an error creating the MilStdSymbol " + symbolCode + ": " + "- ");
+            jsonOutput.append(exc.getMessage() + " - ");
+            jsonOutput.append(st);
+            jsonOutput.append("\"}");
+
+            ErrorLogger.LogException("MultiPointHandler", "RenderBasicShape", exc);
+        }
+
+        boolean debug = false;
+        if (debug == true) {
+            System.out.println("Symbol Code: " + symbolCode);
+            System.out.println("Scale: " + scale);
+            System.out.println("BBOX: " + bbox);
+            if (controlPoints != null) {
+                System.out.println("Geo Points: " + controlPoints);
+            }
+            if (bbox != null) {
+                System.out.println("geo bounds: " + bbox);
+            }
+            if (rect != null) {
+                System.out.println("pixel bounds: " + rect.toString());
+            }
+            if (jsonOutput != null) {
+                System.out.println(jsonOutput.toString());
+            }
+        }
+
+        ErrorLogger.LogMessage("MultiPointHandler", "RenderBasicShape()", "exit RenderBasicShape", Level.FINER);
+        return jsonOutput.toString();
+
+    }
 }

--- a/renderer/src/main/java/armyc2/c5isr/web/render/WebRenderer.java
+++ b/renderer/src/main/java/armyc2/c5isr/web/render/WebRenderer.java
@@ -441,6 +441,120 @@ public final class WebRenderer /* extends Applet */ {
 		return mSymbol;
     }
 
+    /**
+     * Renders basic shapes as symbols, creating MilStdSymbol that contains the
+     * information needed to draw the shape on the map.
+     * ArrayList&lt;Point2D&gt; milStdSymbol.getSymbolShapes.get(index).getPolylines()
+     * and
+     * ShapeInfo = milStdSymbol.getModifierShapes.get(index).
+     *
+     *
+     * @param id
+     *            A unique identifier used to identify the symbol by Google map.
+     *            The id will be the folder name that contains the graphic.
+     * @param name
+     *            a string used to display to the user as the name of the
+     *            graphic being created.
+     * @param description
+     *            a brief description about the graphic being made and what it
+     *            represents.
+     * @param basicShapeType
+     *            {@link armyc2.c5isr.JavaLineArray.BasicShapes}
+     * @param controlPoints
+     *            The vertices of the graphics that make up the graphic. Passed
+     *            in the format of a string, using decimal degrees separating
+     *            lat and lon by a comma, separating coordinates by a space. The
+     *            following format shall be used "x1,y1[,z1] [xn,yn[,zn]]..."
+     * @param altitudeMode
+     *            Indicates whether the symbol should interpret altitudes as
+     *            above sea level or above ground level. Options are
+     *            "clampToGround", "relativeToGround" (from surface of earth),
+     *            "absolute" (sea level), "relativeToSeaFloor" (from the bottom
+     *            of major bodies of water).
+     * @param scale
+     *            A number corresponding to how many meters one meter of our map
+     *            represents. A value "50000" would mean 1:50K which means for
+     *            every meter of our map it represents 50000 meters of real
+     *            world distance.
+     * @param bbox
+     *            The viewable area of the map. Passed in the format of a string
+     *            "lowerLeftX,lowerLeftY,upperRightX,upperRightY." Not required
+     *            but can speed up rendering in some cases. example:
+     *            "-50.4,23.6,-42.2,24.2"
+     * @param modifiers
+     *            Used like:
+     *            modifiers.put(Modifiers.T_UNIQUE_DESIGNATION_1, "T");
+     *            Or
+     *            modifiers.put(Modifiers.AM_DISTANCE, "1000,2000,3000");
+     * @param attributes
+     * 			  Used like:
+     *            attributes.put(MilStdAttributes.LineWidth, "3");
+     *            Or
+     *            attributes.put(MilStdAttributes.LineColor, "#00FF00");
+     * @return MilStdSymbol
+     */
+    public static MilStdSymbol RenderBasicShapeAsMilStdSymbol(String id, String name, String description, int basicShapeType,
+                                                              String controlPoints, String altitudeMode, double scale, String bbox, Map<String, String> modifiers, Map<String, String> attributes) {
+        MilStdSymbol mSymbol = null;
+        try {
+            if (SymbolUtilities.isBasicShape(basicShapeType))
+                mSymbol = MultiPointHandler.RenderBasicShapeAsMilStdSymbol(id, name, description, basicShapeType,
+                        controlPoints, scale, bbox, modifiers, attributes);
+        } catch (Exception ea) {
+            mSymbol = null;
+            ErrorLogger.LogException("WebRenderer", "RenderBasicShapeAsMilStdSymbol" + " - " + basicShapeType, ea, Level.WARNING);
+        }
+
+        return mSymbol;
+    }
+
+    /**
+     * Renders multipoint basic shapes, creating KML that can be used to draw
+     * it on a Google map.
+     * @param id A unique identifier used to identify the symbol by Google map.
+     * The id will be the folder name that contains the graphic.
+     * @param name a string used to display to the user as the name of the
+     * graphic being created.
+     * @param description a brief description about the graphic being made and
+     * what it represents.
+     * @param basicShapeType {@link armyc2.c5isr.JavaLineArray.BasicShapes}
+     * @param controlPoints The vertices of the graphics that make up the
+     * graphic.  Passed in the format of a string, using decimal degrees
+     * separating lat and lon by a comma, separating coordinates by a space.
+     * The following format shall be used "x1,y1[,z1] [xn,yn[,zn]]..."
+     * @param altitudeMode Indicates whether the symbol should interpret
+     * altitudes as above sea level or above ground level. Options are
+     * "clampToGround", "relativeToGround" (from surface of earth), "absolute"
+     * (sea level), "relativeToSeaFloor" (from the bottom of major bodies of
+     * water).
+     * @param scale A number corresponding to how many meters one meter of our
+     * map represents. A value "50000" would mean 1:50K which means for every
+     * meter of our map it represents 50000 meters of real world distance.
+     * @param bbox The viewable area of the map.  Passed in the format of a
+     * string "lowerLeftX,lowerLeftY,upperRightX,upperRightY." Not required
+     * but can speed up rendering in some cases.
+     * example: "-50.4,23.6,-42.2,24.2"
+     * @param modifiers keyed using constants from Modifiers.
+     * Pass in comma delimited String for modifiers with multiple values like AM, AN &amp; X
+     * @param attributes keyed using constants from MilStdAttributes.
+     * @param format An enumeration: 2 for GeoJSON.
+     * @return A JSON string representation of the graphic.
+     */
+    public static String RenderBasicShape(String id, String name, String description, int basicShapeType,
+                                          String controlPoints, String altitudeMode,
+                                          double scale, String bbox, Map<String, String> modifiers, Map<String, String> attributes, int format) {
+        String output = "";
+        try {
+            JavaRendererUtilities.addAltModeToModifiersString(attributes, altitudeMode);
+            if (SymbolUtilities.isBasicShape(basicShapeType))
+                output = MultiPointHandler.RenderBasicShape(id, name, description, basicShapeType, controlPoints,
+                    scale, bbox, modifiers, attributes, format);
+        } catch (Exception ea) {
+            output = "{\"type\":'error',error:'There was an error creating the MilStdSymbol - " + ea.toString() + "'}";
+            ErrorLogger.LogException("WebRenderer", "RenderBasicShape", ea, Level.WARNING);
+        }
+        return output;
+    }
 
     
     /**


### PR DESCRIPTION
- Adds support to render basic shapes through `WebRenderer.RenderBasicShapeAsMilStdSymbol()` and `WebRenderer.RenderBasicShape()`. Method arguments match `RenderMultiPointAsMilStdSymbol()` and `RenderSymbol()`
- Basic shapes have no symbol code so they must use the basic shape render methods and a case from `BasicShapes` class