### PR TITLE
2525E Change 1 mulitpoints

### DIFF
--- a/renderer-test3/src/main/java/armyc2/c5isr/renderer/test3/MyView.java
+++ b/renderer-test3/src/main/java/armyc2/c5isr/renderer/test3/MyView.java
@@ -85,7 +85,7 @@ public class MyView extends View {
             String symbolID  = MainActivity.lineType;
             if (SymbolUtilities.isNumber(symbolID)) {
                 if (symbolID.length() >= 2 && symbolID.length() <= 8) {
-                    symbolID = "" + SymbolID.Version_2525Dch1 + SymbolID.StandardIdentity_Context_Reality +
+                    symbolID = "" + SymbolID.Version_2525Ech1 + SymbolID.StandardIdentity_Context_Reality +
                             SymbolID.StandardIdentity_Affiliation_Friend + symbolID.substring(0, 2) +
                             SymbolID.Status_Present + SymbolID.HQTFD_Unknown + SymbolID.Echelon_Team_Crew +
                             symbolID.substring(2);

--- a/renderer-test3/src/main/java/armyc2/c5isr/renderer/test3/utility.java
+++ b/renderer-test3/src/main/java/armyc2/c5isr/renderer/test3/utility.java
@@ -151,6 +151,16 @@ public final class utility {
                 lowerLatitude, rightLongitude);
         ArrayList<POINT2> pts2 = PixelsToLatLong(pts, converter);
 
+        if (symbolCode.length() >= 2 && symbolCode.length() <= 8) {
+            symbolCode = "" + SymbolID.Version_2525Ech1 + SymbolID.StandardIdentity_Context_Reality +
+                    SymbolID.StandardIdentity_Affiliation_Friend + symbolCode.substring(0,2) +
+                    SymbolID.Status_Present + SymbolID.HQTFD_Unknown + SymbolID.Echelon_Team_Crew +
+                    symbolCode.substring(2);
+        }
+
+        while (symbolCode.length() < 30) {
+            symbolCode += "0";
+        }
         boolean useDashArray=true;
         //uncomment the line to allow renderer to calculate the dashes
         //comment following line if client intends to calculate dashed lines to improve performance

--- a/renderer/src/main/java/armyc2/c5isr/JavaLineArray/CELineArray.java
+++ b/renderer/src/main/java/armyc2/c5isr/JavaLineArray/CELineArray.java
@@ -77,6 +77,7 @@ public final class CELineArray {
                     lResult = 2 * lElements + 8;
                     break;
                 case TacticalLines.FRONTAL_ATTACK:
+                case TacticalLines.TURNING_MOVEMENT:
                     lResult = 2 * lElements + 10;
                     break;
                 case TacticalLines.CATK:
@@ -134,6 +135,7 @@ public final class CELineArray {
                 case TacticalLines.SPT:
                 case TacticalLines.SPT_STRAIGHT:
                 case TacticalLines.FRONTAL_ATTACK:
+                case TacticalLines.TURNING_MOVEMENT:
                 case TacticalLines.UNSP:
                 case TacticalLines.SFENCE:
                 case TacticalLines.DFENCE:

--- a/renderer/src/main/java/armyc2/c5isr/JavaLineArray/CELineArray.java
+++ b/renderer/src/main/java/armyc2/c5isr/JavaLineArray/CELineArray.java
@@ -77,8 +77,10 @@ public final class CELineArray {
                     lResult = 2 * lElements + 8;
                     break;
                 case TacticalLines.FRONTAL_ATTACK:
+                    lResult = 2 * lElements + 15;
+                    break;
                 case TacticalLines.TURNING_MOVEMENT:
-                    lResult = 2 * lElements + 10;
+                    lResult = 2 * lElements + 14;
                     break;
                 case TacticalLines.MOVEMENT_TO_CONTACT:
                     lResult = 2 * lElements + 24;

--- a/renderer/src/main/java/armyc2/c5isr/JavaLineArray/CELineArray.java
+++ b/renderer/src/main/java/armyc2/c5isr/JavaLineArray/CELineArray.java
@@ -80,6 +80,9 @@ public final class CELineArray {
                 case TacticalLines.TURNING_MOVEMENT:
                     lResult = 2 * lElements + 10;
                     break;
+                case TacticalLines.MOVEMENT_TO_CONTACT:
+                    lResult = 2 * lElements + 24;
+                    break;
                 case TacticalLines.CATK:
                     lResult = 2 * lElements + 8;
                     break;
@@ -136,6 +139,7 @@ public final class CELineArray {
                 case TacticalLines.SPT_STRAIGHT:
                 case TacticalLines.FRONTAL_ATTACK:
                 case TacticalLines.TURNING_MOVEMENT:
+                case TacticalLines.MOVEMENT_TO_CONTACT:
                 case TacticalLines.UNSP:
                 case TacticalLines.SFENCE:
                 case TacticalLines.DFENCE:

--- a/renderer/src/main/java/armyc2/c5isr/JavaLineArray/CELineArray.java
+++ b/renderer/src/main/java/armyc2/c5isr/JavaLineArray/CELineArray.java
@@ -76,6 +76,9 @@ public final class CELineArray {
                     //they have an extra 8 points for the arrowhead
                     lResult = 2 * lElements + 8;
                     break;
+                case TacticalLines.FRONTAL_ATTACK:
+                    lResult = 2 * lElements + 10;
+                    break;
                 case TacticalLines.CATK:
                     lResult = 2 * lElements + 8;
                     break;
@@ -130,6 +133,7 @@ public final class CELineArray {
                 case TacticalLines.MAIN_STRAIGHT:
                 case TacticalLines.SPT:
                 case TacticalLines.SPT_STRAIGHT:
+                case TacticalLines.FRONTAL_ATTACK:
                 case TacticalLines.UNSP:
                 case TacticalLines.SFENCE:
                 case TacticalLines.DFENCE:

--- a/renderer/src/main/java/armyc2/c5isr/JavaLineArray/Channels.java
+++ b/renderer/src/main/java/armyc2/c5isr/JavaLineArray/Channels.java
@@ -2191,17 +2191,24 @@ public final class Channels {
                     }
 
                     if (vbiDrawThis == TacticalLines.MOVEMENT_TO_CONTACT) {
-                        midPt1 = lineutility.MidPointDouble(pLinePoints[vblLowerCounter + vblUpperCounter + 1], pLinePoints[vblLowerCounter + vblUpperCounter + 6], 0);
-                        midPt1 = lineutility.ExtendDirectedLine(pLinePoints[vblLowerCounter + vblUpperCounter + 1], pLinePoints[vblLowerCounter + vblUpperCounter + 6], midPt1, lineutility.extend_above, vblChannelWidth / 8.0);
-                        midPt2 = lineutility.MidPointDouble(pLinePoints[vblLowerCounter + vblUpperCounter + 5], pLinePoints[vblLowerCounter + vblUpperCounter + 6], 0);
-                        midPt2 = lineutility.ExtendDirectedLine(pLinePoints[vblLowerCounter + vblUpperCounter + 5], pLinePoints[vblLowerCounter + vblUpperCounter + 6], midPt2, lineutility.extend_below, vblChannelWidth / 8.0);
+                        pt0 = new POINT2(pLinePoints[vblLowerCounter + vblUpperCounter + 1]); // arrow head left
+                        ptCenter = new POINT2(pLinePoints[vblLowerCounter + vblUpperCounter + 6]); // arrow head tip
+                        pt1 = new POINT2(pLinePoints[vblLowerCounter + vblUpperCounter + 5]); // arrow right
+
+                        int direction1 = lineutility.reverseDirection(lineutility.CalcDirectionFromLine(pt0, ptCenter, pt1));
+                        int direction2 = lineutility.reverseDirection(lineutility.CalcDirectionFromLine(pt1, ptCenter, pt0));
+
+                        midPt1 = lineutility.MidPointDouble(pt0, ptCenter, 0);
+                        midPt1 = lineutility.ExtendDirectedLine(pt0, ptCenter, midPt1, direction1, vblChannelWidth / 8.0);
+                        midPt2 = lineutility.MidPointDouble(pt1, ptCenter, 0);
+                        midPt2 = lineutility.ExtendDirectedLine(pt1, ptCenter, midPt2, direction2, vblChannelWidth / 8.0);
 
                         POINT2[] DISMPts = new POINT2[16];
                         lineutility.InitializePOINT2Array(DISMPts);
-                        DISMPts[0] = lineutility.ExtendDirectedLine(pLinePoints[vblLowerCounter + vblUpperCounter + 1], pLinePoints[vblLowerCounter + vblUpperCounter + 6], midPt1, lineutility.extend_above, vblChannelWidth);
+                        DISMPts[0] = lineutility.ExtendDirectedLine(pt0, ptCenter, midPt1, direction1, vblChannelWidth);
                         DISMPts[1] = midPt1;
                         DISMPts[2] = midPt2;
-                        DISMPts[3] = lineutility.ExtendDirectedLine(pLinePoints[vblLowerCounter + vblUpperCounter + 5], pLinePoints[vblLowerCounter + vblUpperCounter + 6], midPt2, lineutility.extend_below, vblChannelWidth);
+                        DISMPts[3] = lineutility.ExtendDirectedLine(pt1, ptCenter, midPt2, direction2, vblChannelWidth);
 
                         lHowManyThisSegment = DISMSupport.GetDISMCoverDoubleRevC(DISMPts, vbiDrawThis, 4);
                         for (int i = 0; i < lHowManyThisSegment; i++) {

--- a/renderer/src/main/java/armyc2/c5isr/JavaLineArray/Channels.java
+++ b/renderer/src/main/java/armyc2/c5isr/JavaLineArray/Channels.java
@@ -782,6 +782,7 @@ public final class Channels {
                 case TacticalLines.SPT:
                 case TacticalLines.FRONTAL_ATTACK:
                 case TacticalLines.TURNING_MOVEMENT:
+                case TacticalLines.MOVEMENT_TO_CONTACT:
                 case TacticalLines.AAAAA:
                 case TacticalLines.AIRAOA:
                 case TacticalLines.CATK:
@@ -842,6 +843,7 @@ public final class Channels {
                 case TacticalLines.SPT_STRAIGHT:
                 case TacticalLines.FRONTAL_ATTACK:
                 case TacticalLines.TURNING_MOVEMENT:
+                case TacticalLines.MOVEMENT_TO_CONTACT:
                 case TacticalLines.TRIPLE:
                 case TacticalLines.DOUBLEC:
                 case TacticalLines.SINGLEC:
@@ -1318,6 +1320,7 @@ public final class Channels {
                 case TacticalLines.SPT_STRAIGHT:
                 case TacticalLines.FRONTAL_ATTACK:
                 case TacticalLines.TURNING_MOVEMENT:
+                case TacticalLines.MOVEMENT_TO_CONTACT:
                 case TacticalLines.MAIN:
                 case TacticalLines.MAIN_STRAIGHT:
                 case TacticalLines.CATKBYFIRE:	//80
@@ -1346,6 +1349,7 @@ public final class Channels {
                 case TacticalLines.SPT_STRAIGHT:
                 case TacticalLines.FRONTAL_ATTACK:
                 case TacticalLines.TURNING_MOVEMENT:
+                case TacticalLines.MOVEMENT_TO_CONTACT:
                 case TacticalLines.CATK:
                 case TacticalLines.CATKBYFIRE:
                 case TacticalLines.TRIPLE:
@@ -1867,6 +1871,7 @@ public final class Channels {
                 case TacticalLines.SPT_STRAIGHT:
                 case TacticalLines.FRONTAL_ATTACK:
                 case TacticalLines.TURNING_MOVEMENT:
+                case TacticalLines.MOVEMENT_TO_CONTACT:
                 case TacticalLines.CATK:
                 case TacticalLines.CATKBYFIRE:
                 case TacticalLines.AIRAOA:
@@ -1883,6 +1888,8 @@ public final class Channels {
                         vblCounter = vblLowerCounter + vblUpperCounter + 19;
                     } else if (vbiDrawThis == (long) TacticalLines.FRONTAL_ATTACK || vbiDrawThis ==  TacticalLines.TURNING_MOVEMENT) {
                         vblCounter = vblLowerCounter + vblUpperCounter + 10;
+                    } else if (vbiDrawThis == (long) TacticalLines.MOVEMENT_TO_CONTACT) {
+                        vblCounter = vblLowerCounter + vblUpperCounter + 24;
                     }
 
                     pLinePoints = new POINT2[vblCounter];
@@ -2176,6 +2183,25 @@ public final class Channels {
                         pLinePoints[vblLowerCounter + vblUpperCounter + 9] = lineutility.ExtendDirectedLine(pt0, pt1, midPt1, lineutility.extend_below, vblChannelWidth / 2, 5);
                     }
 
+                    if (vbiDrawThis == TacticalLines.MOVEMENT_TO_CONTACT) {
+                        midPt1 = lineutility.MidPointDouble(pLinePoints[vblLowerCounter + vblUpperCounter + 1], pLinePoints[vblLowerCounter + vblUpperCounter + 6], 0);
+                        midPt1 = lineutility.ExtendDirectedLine(pLinePoints[vblLowerCounter + vblUpperCounter + 1], pLinePoints[vblLowerCounter + vblUpperCounter + 6], midPt1, lineutility.extend_above, vblChannelWidth / 8.0);
+                        midPt2 = lineutility.MidPointDouble(pLinePoints[vblLowerCounter + vblUpperCounter + 5], pLinePoints[vblLowerCounter + vblUpperCounter + 6], 0);
+                        midPt2 = lineutility.ExtendDirectedLine(pLinePoints[vblLowerCounter + vblUpperCounter + 5], pLinePoints[vblLowerCounter + vblUpperCounter + 6], midPt2, lineutility.extend_below, vblChannelWidth / 8.0);
+
+                        POINT2[] DISMPts = new POINT2[16];
+                        lineutility.InitializePOINT2Array(DISMPts);
+                        DISMPts[0] = lineutility.ExtendDirectedLine(pLinePoints[vblLowerCounter + vblUpperCounter + 1], pLinePoints[vblLowerCounter + vblUpperCounter + 6], midPt1, lineutility.extend_above, vblChannelWidth);
+                        DISMPts[1] = midPt1;
+                        DISMPts[2] = midPt2;
+                        DISMPts[3] = lineutility.ExtendDirectedLine(pLinePoints[vblLowerCounter + vblUpperCounter + 5], pLinePoints[vblLowerCounter + vblUpperCounter + 6], midPt2, lineutility.extend_below, vblChannelWidth);
+
+                        lHowManyThisSegment = DISMSupport.GetDISMCoverDoubleRevC(DISMPts, vbiDrawThis, 4);
+                        for (int i = 0; i < lHowManyThisSegment; i++) {
+                            pLinePoints[vblLowerCounter + vblUpperCounter + 8 + i] = DISMPts[i];
+                        }
+                    }
+
                     break;
                 default:
                     break;
@@ -2298,6 +2324,53 @@ public final class Channels {
                             }
                         }
                         if(k==vblCounter-1) //non-LC should only have one shape
+                        {
+                            if(shape !=null && shape.getShape() != null)
+                            {
+                                shapes.add(shape);
+                            }
+                        }
+                        break;
+                    case TacticalLines.MOVEMENT_TO_CONTACT:
+                        if(beginLine)
+                        {
+                            if(k>0)
+                            {
+                                if(pLinePoints[k].style==5 && pLinePoints[k-1].style==5 && k != vblCounter-1)
+                                    continue;
+                            }
+
+                            if (pLinePoints[k].style == 9 && pLinePoints[k - 1].style != 9)
+                            {
+                                if (!shape.getPoints().isEmpty())
+                                    shapes.add(shape);
+                                shape = new Shape2(Shape2.SHAPE_TYPE_FILL);
+                                shape.set_Style(pLinePoints[k].style);
+                                shape.setFillColor(tg.get_LineColor());
+                                shape.set_Fillstyle(1);
+                            }
+
+                            shape.moveTo(pLinePoints[k]);
+                            beginLine=false;
+                        }
+                        else
+                        {
+                            shape.lineTo(pLinePoints[k]);
+                            if(pLinePoints[k].style==5)
+                            {
+                                beginLine=true;
+                            }
+                            else if (pLinePoints[k].style == 10)
+                            {
+                                if (shape != null && shape.getShape() != null)
+                                {
+                                    shapes.add(0, shape);
+                                    shape = new Shape2(Shape2.SHAPE_TYPE_POLYLINE);
+                                }
+                                beginLine = true;
+                            }
+                        }
+                        if(k==vblCounter-1)
                         {
                             if(shape !=null && shape.getShape() != null)
                             {
@@ -2545,6 +2618,30 @@ public final class Channels {
                     newPts.add(pLinePoints[n-6]);
 
                     for(j=n-11;j>=(n-10)/2;j--)
+                    {
+                        newPts.add(pLinePoints[j]);
+                    }
+                    shape=new Shape2(Shape2.SHAPE_TYPE_FILL);
+                    shape.moveTo(newPts.get(0));
+                    t=newPts.size();
+                    for(j=1;j<t;j++)
+                    {
+                        shape.lineTo(newPts.get(j));
+                    }
+                    break;
+                case TacticalLines.MOVEMENT_TO_CONTACT:
+                    for(j=0;j<(n-24)/2;j++)
+                    {
+                        newPts.add(pLinePoints[j]);
+                    }
+                    //add the arrow outline
+                    newPts.add(pLinePoints[n-22]);
+                    newPts.add(pLinePoints[n-23]);
+                    newPts.add(pLinePoints[n-24]);
+                    newPts.add(pLinePoints[n-19]);
+                    newPts.add(pLinePoints[n-20]);
+
+                    for(j=n-25;j>=(n-24)/2;j--)
                     {
                         newPts.add(pLinePoints[j]);
                     }

--- a/renderer/src/main/java/armyc2/c5isr/JavaLineArray/Channels.java
+++ b/renderer/src/main/java/armyc2/c5isr/JavaLineArray/Channels.java
@@ -1886,8 +1886,10 @@ public final class Channels {
                     //diagnostic
                     if (vbiDrawThis == (long) TacticalLines.AAAAA) {
                         vblCounter = vblLowerCounter + vblUpperCounter + 19;
-                    } else if (vbiDrawThis == (long) TacticalLines.FRONTAL_ATTACK || vbiDrawThis ==  TacticalLines.TURNING_MOVEMENT) {
-                        vblCounter = vblLowerCounter + vblUpperCounter + 10;
+                    } else if (vbiDrawThis == (long) TacticalLines.FRONTAL_ATTACK) {
+                        vblCounter = vblLowerCounter + vblUpperCounter + 15;
+                    } else if (vbiDrawThis ==  TacticalLines.TURNING_MOVEMENT) {
+                        vblCounter = vblLowerCounter + vblUpperCounter + 14;
                     } else if (vbiDrawThis == (long) TacticalLines.MOVEMENT_TO_CONTACT) {
                         vblCounter = vblLowerCounter + vblUpperCounter + 24;
                     }
@@ -2199,6 +2201,83 @@ public final class Channels {
                         lHowManyThisSegment = DISMSupport.GetDISMCoverDoubleRevC(DISMPts, vbiDrawThis, 4);
                         for (int i = 0; i < lHowManyThisSegment; i++) {
                             pLinePoints[vblLowerCounter + vblUpperCounter + 8 + i] = DISMPts[i];
+                        }
+                    }
+
+                    if (vbiDrawThis == TacticalLines.FRONTAL_ATTACK || vbiDrawThis == TacticalLines.TURNING_MOVEMENT) {
+                        pt0 = new POINT2(pLinePoints[vblLowerCounter + vblUpperCounter+2]); // top left
+                        pt1 = lineutility.MidPointDouble(pLinePoints[vblLowerCounter + vblUpperCounter + 1], pLinePoints[vblLowerCounter + vblUpperCounter + 6], 0); // top right
+                        pt2 = new POINT2(pLinePoints[vblLowerCounter + vblUpperCounter+4]); // bottom left
+                        pt3 = lineutility.MidPointDouble(pLinePoints[vblLowerCounter + vblUpperCounter + 5], pLinePoints[vblLowerCounter + vblUpperCounter + 6], 0); // bottom right
+
+                        // Shrink vertically to add spacing between arrow lines
+                        dist = lineutility.CalcDistanceDouble(pt0, pt2) / 4;
+                        pt0 = lineutility.ExtendAlongLineDouble2(pt0, pt2, dist);
+                        pt1 = lineutility.ExtendAlongLineDouble2(pt1, pt3, dist);
+                        pt2 = lineutility.ExtendAlongLineDouble2(pt2, pt0, dist);
+                        pt3 = lineutility.ExtendAlongLineDouble2(pt3, pt1, dist);
+
+                        // Make height twice size of width
+                        if (lineutility.CalcDistanceDouble(pt0, pt2) > 2 * lineutility.CalcDistanceDouble(pt0, pt1)) {
+                            // Shrink vertical
+                            dist = lineutility.CalcDistanceDouble(pt0, pt1);
+
+                            midPt1 = lineutility.MidPointDouble(pt0, pt2, 0);
+                            pt0 = lineutility.ExtendAlongLineDouble2(midPt1, pt0, dist);
+                            pt2 = lineutility.ExtendAlongLineDouble2(midPt1, pt2, dist);
+
+                            midPt1 = lineutility.MidPointDouble(pt1, pt3, 0);
+                            pt1 = lineutility.ExtendAlongLineDouble2(midPt1, pt1, dist);
+                            pt3 = lineutility.ExtendAlongLineDouble2(midPt1, pt3, dist);
+                        } else if (2 * lineutility.CalcDistanceDouble(pt0, pt1) > lineutility.CalcDistanceDouble(pt0, pt2)) {
+                            //Shrink horizontal
+                            dist = lineutility.CalcDistanceDouble(pt0, pt2) / 2;
+                            pt1 = lineutility.ExtendAlongLineDouble2(pt0, pt1, dist);
+                            pt3 = lineutility.ExtendAlongLineDouble2(pt2, pt3, dist);
+                        }
+
+                        // Want actual top / left if arrow head is rotated
+                        if (pt0.y > pt2.y && pt1.y > pt3.y) {
+                            pt4 = pt0;
+                            pt0 = pt2;
+                            pt2 = pt4;
+
+                            pt4 = pt1;
+                            pt1 = pt3;
+                            pt3 = pt4;
+                        }
+                        if (pt0.x > pt1.x && pt2.x > pt3.x) {
+                            pt4 = pt0;
+                            pt0 = pt1;
+                            pt1 = pt4;
+
+                            pt4 = pt2;
+                            pt2 = pt3;
+                            pt3 = pt4;
+                        }
+
+                        if (vbiDrawThis == TacticalLines.FRONTAL_ATTACK) {
+                            // Draw "A"
+                            pLinePoints[vblLowerCounter + vblUpperCounter + 10] = new POINT2(pt2);
+                            pLinePoints[vblLowerCounter + vblUpperCounter + 10].style = 0;
+                            pLinePoints[vblLowerCounter + vblUpperCounter + 11] = lineutility.MidPointDouble(pt0, pt1, 0);
+                            pLinePoints[vblLowerCounter + vblUpperCounter + 11].style = 0;
+                            pLinePoints[vblLowerCounter + vblUpperCounter + 12] = new POINT2(pt3);
+                            pLinePoints[vblLowerCounter + vblUpperCounter + 12].style = 5;
+                            pLinePoints[vblLowerCounter + vblUpperCounter + 13] = lineutility.MidPointDouble(pLinePoints[vblLowerCounter + vblUpperCounter + 10], pLinePoints[vblLowerCounter + vblUpperCounter + 11], 0);
+                            pLinePoints[vblLowerCounter + vblUpperCounter + 13].style = 0;
+                            pLinePoints[vblLowerCounter + vblUpperCounter + 14] = lineutility.MidPointDouble(pLinePoints[vblLowerCounter + vblUpperCounter + 11], pLinePoints[vblLowerCounter + vblUpperCounter + 12], 5);
+                            pLinePoints[vblLowerCounter + vblUpperCounter + 14].style = 5;
+                        } else {
+                            // Draw "T"
+                            pLinePoints[vblLowerCounter + vblUpperCounter + 10] = lineutility.MidPointDouble(pt0, pt1, 0);
+                            pLinePoints[vblLowerCounter + vblUpperCounter + 10].style = 0;
+                            pLinePoints[vblLowerCounter + vblUpperCounter + 11] = lineutility.MidPointDouble(pt2, pt3, 5);
+                            pLinePoints[vblLowerCounter + vblUpperCounter + 11].style = 5;
+                            pLinePoints[vblLowerCounter + vblUpperCounter + 12] = new POINT2(pt0);
+                            pLinePoints[vblLowerCounter + vblUpperCounter + 12].style = 0;
+                            pLinePoints[vblLowerCounter + vblUpperCounter + 13] = new POINT2(pt1);
+                            pLinePoints[vblLowerCounter + vblUpperCounter + 13].style = 5;
                         }
                     }
 

--- a/renderer/src/main/java/armyc2/c5isr/JavaLineArray/Channels.java
+++ b/renderer/src/main/java/armyc2/c5isr/JavaLineArray/Channels.java
@@ -781,6 +781,7 @@ public final class Channels {
                 case TacticalLines.SPT_STRAIGHT:
                 case TacticalLines.SPT:
                 case TacticalLines.FRONTAL_ATTACK:
+                case TacticalLines.TURNING_MOVEMENT:
                 case TacticalLines.AAAAA:
                 case TacticalLines.AIRAOA:
                 case TacticalLines.CATK:
@@ -840,6 +841,7 @@ public final class Channels {
                 case TacticalLines.SPT:
                 case TacticalLines.SPT_STRAIGHT:
                 case TacticalLines.FRONTAL_ATTACK:
+                case TacticalLines.TURNING_MOVEMENT:
                 case TacticalLines.TRIPLE:
                 case TacticalLines.DOUBLEC:
                 case TacticalLines.SINGLEC:
@@ -1315,6 +1317,7 @@ public final class Channels {
                 case TacticalLines.SPT:
                 case TacticalLines.SPT_STRAIGHT:
                 case TacticalLines.FRONTAL_ATTACK:
+                case TacticalLines.TURNING_MOVEMENT:
                 case TacticalLines.MAIN:
                 case TacticalLines.MAIN_STRAIGHT:
                 case TacticalLines.CATKBYFIRE:	//80
@@ -1342,6 +1345,7 @@ public final class Channels {
                 case TacticalLines.SPT:
                 case TacticalLines.SPT_STRAIGHT:
                 case TacticalLines.FRONTAL_ATTACK:
+                case TacticalLines.TURNING_MOVEMENT:
                 case TacticalLines.CATK:
                 case TacticalLines.CATKBYFIRE:
                 case TacticalLines.TRIPLE:
@@ -1862,6 +1866,7 @@ public final class Channels {
                 case TacticalLines.SPT:
                 case TacticalLines.SPT_STRAIGHT:
                 case TacticalLines.FRONTAL_ATTACK:
+                case TacticalLines.TURNING_MOVEMENT:
                 case TacticalLines.CATK:
                 case TacticalLines.CATKBYFIRE:
                 case TacticalLines.AIRAOA:
@@ -1876,7 +1881,7 @@ public final class Channels {
                     //diagnostic
                     if (vbiDrawThis == (long) TacticalLines.AAAAA) {
                         vblCounter = vblLowerCounter + vblUpperCounter + 19;
-                    } else if (vbiDrawThis == (long) TacticalLines.FRONTAL_ATTACK) {
+                    } else if (vbiDrawThis == (long) TacticalLines.FRONTAL_ATTACK || vbiDrawThis ==  TacticalLines.TURNING_MOVEMENT) {
                         vblCounter = vblLowerCounter + vblUpperCounter + 10;
                     }
 
@@ -2162,6 +2167,15 @@ public final class Channels {
                         pLinePoints[vblLowerCounter + vblUpperCounter + 9] = lineutility.PointRelativeToLine(pt0, pt1, pt1, ptCenter);
                         pLinePoints[vblLowerCounter + vblUpperCounter + 9].style = 5;
                     }
+
+                    if (vbiDrawThis == TacticalLines.TURNING_MOVEMENT) {
+                        pt0 = tg.Pixels.get(tg.Pixels.size()-2);
+                        pt1 = tg.Pixels.get(tg.Pixels.size()-3);
+                        midPt1 = lineutility.MidPointDouble(pt0, pt1, 0);
+                        pLinePoints[vblLowerCounter + vblUpperCounter + 8] = lineutility.ExtendDirectedLine(pt0, pt1, midPt1, lineutility.extend_above, vblChannelWidth / 2, 0);
+                        pLinePoints[vblLowerCounter + vblUpperCounter + 9] = lineutility.ExtendDirectedLine(pt0, pt1, midPt1, lineutility.extend_below, vblChannelWidth / 2, 5);
+                    }
+
                     break;
                 default:
                     break;
@@ -2262,6 +2276,7 @@ public final class Channels {
                     case TacticalLines.SPT_STRAIGHT:
                     case TacticalLines.AIRAOA:
                     case TacticalLines.FRONTAL_ATTACK:
+                    case TacticalLines.TURNING_MOVEMENT:
                         if(beginLine)
                         {
                             if(k>0) //doubled points with linestyle=5
@@ -2517,6 +2532,7 @@ public final class Channels {
                     }
                     break;
                 case TacticalLines.FRONTAL_ATTACK:
+                case TacticalLines.TURNING_MOVEMENT:
                     for(j=0;j<(n-10)/2;j++)
                     {
                         newPts.add(pLinePoints[j]);

--- a/renderer/src/main/java/armyc2/c5isr/JavaLineArray/Channels.java
+++ b/renderer/src/main/java/armyc2/c5isr/JavaLineArray/Channels.java
@@ -2178,8 +2178,13 @@ public final class Channels {
                     }
 
                     if (vbiDrawThis == TacticalLines.TURNING_MOVEMENT) {
-                        pt0 = tg.Pixels.get(tg.Pixels.size()-2);
-                        pt1 = tg.Pixels.get(tg.Pixels.size()-3);
+                        if (tg.Pixels.size() == 3) {
+                            pt0 = tg.Pixels.get(1);
+                            pt1 = lineutility.ClosestPointOnLine(tg.Pixels.get(0), tg.Pixels.get(1), tg.Pixels.get(2));
+                        } else { // tg.Pixels.size() > 3
+                            pt0 = tg.Pixels.get(tg.Pixels.size() - 2);
+                            pt1 = tg.Pixels.get(tg.Pixels.size() - 3);
+                        }
                         midPt1 = lineutility.MidPointDouble(pt0, pt1, 0);
                         pLinePoints[vblLowerCounter + vblUpperCounter + 8] = lineutility.ExtendDirectedLine(pt0, pt1, midPt1, lineutility.extend_above, vblChannelWidth / 2, 0);
                         pLinePoints[vblLowerCounter + vblUpperCounter + 9] = lineutility.ExtendDirectedLine(pt0, pt1, midPt1, lineutility.extend_below, vblChannelWidth / 2, 5);

--- a/renderer/src/main/java/armyc2/c5isr/JavaLineArray/Channels.java
+++ b/renderer/src/main/java/armyc2/c5isr/JavaLineArray/Channels.java
@@ -780,6 +780,7 @@ public final class Channels {
             switch (vbiDrawThis) {
                 case TacticalLines.SPT_STRAIGHT:
                 case TacticalLines.SPT:
+                case TacticalLines.FRONTAL_ATTACK:
                 case TacticalLines.AAAAA:
                 case TacticalLines.AIRAOA:
                 case TacticalLines.CATK:
@@ -838,6 +839,7 @@ public final class Channels {
                 case TacticalLines.MAIN_STRAIGHT:
                 case TacticalLines.SPT:
                 case TacticalLines.SPT_STRAIGHT:
+                case TacticalLines.FRONTAL_ATTACK:
                 case TacticalLines.TRIPLE:
                 case TacticalLines.DOUBLEC:
                 case TacticalLines.SINGLEC:
@@ -1312,6 +1314,7 @@ public final class Channels {
                 case TacticalLines.AAAAA:
                 case TacticalLines.SPT:
                 case TacticalLines.SPT_STRAIGHT:
+                case TacticalLines.FRONTAL_ATTACK:
                 case TacticalLines.MAIN:
                 case TacticalLines.MAIN_STRAIGHT:
                 case TacticalLines.CATKBYFIRE:	//80
@@ -1338,6 +1341,7 @@ public final class Channels {
                 case TacticalLines.MAIN_STRAIGHT:
                 case TacticalLines.SPT:
                 case TacticalLines.SPT_STRAIGHT:
+                case TacticalLines.FRONTAL_ATTACK:
                 case TacticalLines.CATK:
                 case TacticalLines.CATKBYFIRE:
                 case TacticalLines.TRIPLE:
@@ -1857,6 +1861,7 @@ public final class Channels {
                     break;
                 case TacticalLines.SPT:
                 case TacticalLines.SPT_STRAIGHT:
+                case TacticalLines.FRONTAL_ATTACK:
                 case TacticalLines.CATK:
                 case TacticalLines.CATKBYFIRE:
                 case TacticalLines.AIRAOA:
@@ -1871,6 +1876,8 @@ public final class Channels {
                     //diagnostic
                     if (vbiDrawThis == (long) TacticalLines.AAAAA) {
                         vblCounter = vblLowerCounter + vblUpperCounter + 19;
+                    } else if (vbiDrawThis == (long) TacticalLines.FRONTAL_ATTACK) {
+                        vblCounter = vblLowerCounter + vblUpperCounter + 10;
                     }
 
                     pLinePoints = new POINT2[vblCounter];
@@ -2138,6 +2145,23 @@ public final class Channels {
                             pLinePoints[vblCounter - k - 1].style = 18;
                         }
                     }
+
+                    if (vbiDrawThis == TacticalLines.FRONTAL_ATTACK) {
+                        // Add line on perpendicular to arrow head
+                        pt0 = new POINT2(pLinePoints[vblLowerCounter + vblUpperCounter + 1]); // arrow head left
+                        ptCenter = new POINT2(pLinePoints[vblLowerCounter + vblUpperCounter + 6]); // arrow head tip
+                        pt1 = new POINT2(pLinePoints[vblLowerCounter + vblUpperCounter + 5]); // arrow right
+
+                        // Make distance between pt0 and pt1 vblChannelWidth * 2
+                        midPt1 = lineutility.MidPointDouble(pt0, pt1, 0);
+                        pt0 = lineutility.ExtendAlongLineDouble(pt1, midPt1, vblChannelWidth);
+                        pt1 = lineutility.ExtendAlongLineDouble(pt0, midPt1, vblChannelWidth);
+
+                        pLinePoints[vblLowerCounter + vblUpperCounter + 8] = lineutility.PointRelativeToLine(pt0, pt1, pt0, ptCenter);
+                        pLinePoints[vblLowerCounter + vblUpperCounter + 8].style = 0;
+                        pLinePoints[vblLowerCounter + vblUpperCounter + 9] = lineutility.PointRelativeToLine(pt0, pt1, pt1, ptCenter);
+                        pLinePoints[vblLowerCounter + vblUpperCounter + 9].style = 5;
+                    }
                     break;
                 default:
                     break;
@@ -2237,6 +2261,7 @@ public final class Channels {
                     case TacticalLines.SPT:
                     case TacticalLines.SPT_STRAIGHT:
                     case TacticalLines.AIRAOA:
+                    case TacticalLines.FRONTAL_ATTACK:
                         if(beginLine)
                         {
                             if(k>0) //doubled points with linestyle=5
@@ -2486,6 +2511,30 @@ public final class Channels {
                     shape.moveTo(newPts.get(0));
                     t=newPts.size();
                     //for(j=1;j<newPts.size();j++)
+                    for(j=1;j<t;j++)
+                    {
+                        shape.lineTo(newPts.get(j));
+                    }
+                    break;
+                case TacticalLines.FRONTAL_ATTACK:
+                    for(j=0;j<(n-10)/2;j++)
+                    {
+                        newPts.add(pLinePoints[j]);
+                    }
+                    //add the arrow outline
+                    newPts.add(pLinePoints[n-8]);
+                    newPts.add(pLinePoints[n-9]);
+                    newPts.add(pLinePoints[n-10]);
+                    newPts.add(pLinePoints[n-5]);
+                    newPts.add(pLinePoints[n-6]);
+
+                    for(j=n-11;j>=(n-10)/2;j--)
+                    {
+                        newPts.add(pLinePoints[j]);
+                    }
+                    shape=new Shape2(Shape2.SHAPE_TYPE_FILL);
+                    shape.moveTo(newPts.get(0));
+                    t=newPts.size();
                     for(j=1;j<t;j++)
                     {
                         shape.lineTo(newPts.get(j));

--- a/renderer/src/main/java/armyc2/c5isr/JavaLineArray/DISMSupport.java
+++ b/renderer/src/main/java/armyc2/c5isr/JavaLineArray/DISMSupport.java
@@ -55,7 +55,7 @@ public final class DISMSupport
         }
         return result;
     }
-    protected static void ArcApproximationDouble(double left, double top, double right, double bottom,
+    private static void ArcApproximationDouble(double left, double top, double right, double bottom,
             double startx, double starty, double endx, double endy, POINT2[] lpoints)
     {
 

--- a/renderer/src/main/java/armyc2/c5isr/JavaLineArray/DISMSupport.java
+++ b/renderer/src/main/java/armyc2/c5isr/JavaLineArray/DISMSupport.java
@@ -427,6 +427,124 @@ public final class DISMSupport
         }
         return counter;
     }
+
+    private static boolean IsEnvelopmentArcReversed(POINT2[] pPoints) {
+        try {
+            if (pPoints.length < 4) {
+                return false;
+            }
+
+            POINT2[] ptsSeize = new POINT2[2];
+            ptsSeize[0] = new POINT2(pPoints[0]);
+            ptsSeize[1] = new POINT2(pPoints[2]);
+            lineutility.CalcClockwiseCenterDouble(ptsSeize);
+            double d = lineutility.CalcDistanceDouble(ptsSeize[0], pPoints[3]);
+
+            ptsSeize[0] = new POINT2(pPoints[2]);
+            ptsSeize[1] = new POINT2(pPoints[0]);
+            lineutility.CalcClockwiseCenterDouble(ptsSeize);
+            double dArcReversed = lineutility.CalcDistanceDouble(ptsSeize[0], pPoints[3]);
+
+            return dArcReversed > d;
+        } catch (Exception exc) {
+            ErrorLogger.LogException(_className, "IsEnvelopmentArcReversed",
+                    new RendererException("IsEnvelopmentArcReversed", exc));
+        }
+        return false;
+    }
+
+    /**
+     * Calculates the points for ENVELOPMENT
+     *
+     * @param points OUT - the client points, also used for the returned points.
+     */
+    protected static int GetEnvelopmentGraphicDouble(POINT2[] points) {
+        int counter=0;
+        try {
+            POINT2[] savepoints = new POINT2[4];
+            double iLength = 0;
+            double iRadius = 0;
+            double iDiagEOL_length = 0;
+            double dAngle1 = 0;
+            double iDeltaX1 = 0;
+            double iDeltaY1 = 0;
+            double iDeltaX2 = 0;
+            double iDeltaY2 = 0;
+            POINT2 ptArcCenter = new POINT2();
+            POINT2[] arcpoints = new POINT2[17];
+            POINT2[] deltapoints = new POINT2[4];
+            int j = 0;
+
+            for (j = 0; j < 4; j++) {
+                savepoints[j] = new POINT2(points[j]);
+            }
+
+            lineutility.InitializePOINT2Array(arcpoints);
+            lineutility.InitializePOINT2Array(deltapoints);
+
+            points[0] = new POINT2(savepoints[0]);
+            points[0].style = 14;
+            counter++;
+            points[1] = lineutility.ClosestPointOnLine(savepoints[0], savepoints[2], savepoints[1]);
+            points[1].style = 5;
+            counter++;
+
+            iLength =  Math.sqrt((points[1].x - points[0].x) * (points[1].x - points[0].x) +
+                    (points[1].y - points[0].y) * (points[1].y - points[0].y));
+            iRadius =  Math.sqrt((points[2].x - points[1].x) * (points[2].x - points[1].x) +
+                    (points[2].y - points[1].y) * (points[2].y - points[1].y)) / 2;
+            iDiagEOL_length = (iLength + iRadius * 2) / 20;
+            dAngle1 = Math.atan2(points[2].y - points[1].y, points[2].x - points[1].x);
+
+            double DPIScaleFactor = RendererSettings.getInstance().getDeviceDPI() / 96.0;
+            if ((double) iDiagEOL_length > maxLength * DPIScaleFactor) {
+                iDiagEOL_length = maxLength * DPIScaleFactor;
+            }
+            if ((double) iDiagEOL_length < minLength * DPIScaleFactor) {   //was minLength
+                iDiagEOL_length = minLength * DPIScaleFactor;
+            }
+
+            // draw the semicircle
+            ptArcCenter.x = (points[1].x + savepoints[2].x) / 2;
+            ptArcCenter.y = (points[1].y + savepoints[2].y) / 2;
+            boolean reverseArc = IsEnvelopmentArcReversed(savepoints);
+            if (reverseArc) {
+                ArcApproximationDouble( (ptArcCenter.x - iRadius), (ptArcCenter.y - iRadius),
+                        (ptArcCenter.x + iRadius), (ptArcCenter.y + iRadius),
+                        points[1].x, points[1].y, savepoints[2].x, savepoints[2].y, arcpoints);
+                dAngle1 += CONST_PI / 2;
+            } else {
+                dAngle1 -= CONST_PI / 2;
+                ArcApproximationDouble((ptArcCenter.x - iRadius), (ptArcCenter.y - iRadius),
+                        (ptArcCenter.x + iRadius), (ptArcCenter.y + iRadius),
+                        savepoints[2].x, savepoints[2].y, points[1].x, points[1].y, arcpoints);
+            }
+
+            // draw the arrow
+            iDeltaX1 = (iDiagEOL_length * Math.cos(dAngle1 - CONST_PI / 4));
+            iDeltaY1 = (iDiagEOL_length * Math.sin(dAngle1 - CONST_PI / 4));
+            iDeltaX2 = (iDiagEOL_length * Math.cos(dAngle1 + CONST_PI / 4));
+            iDeltaY2 = (iDiagEOL_length * Math.sin(dAngle1 + CONST_PI / 4));
+            DrawEndpieceDeltasDouble(savepoints[2],
+                    iDeltaX1, iDeltaY1, iDeltaX2, iDeltaY2, deltapoints);
+
+            for (j = 0; j < 4; j++) {
+                points[counter] = new POINT2(deltapoints[j]);
+                counter++;
+            }
+
+            for (j = 0; j < 17; j++) {
+                points[counter] = new POINT2(arcpoints[j]);
+                points[counter].style = 0;
+                counter++;
+            }
+            points[counter-1].style = 5;
+        } catch (Exception exc) {
+            ErrorLogger.LogException(_className ,"GetEnvelopmentGraphicDouble",
+                    new RendererException("Failed inside GetEnvelopmentGraphicDouble", exc));
+        }
+        return counter;
+    }
     /**
      * Calculates the points for SCREEN, COVER, GUARD, SARA.
      *

--- a/renderer/src/main/java/armyc2/c5isr/JavaLineArray/DISMSupport.java
+++ b/renderer/src/main/java/armyc2/c5isr/JavaLineArray/DISMSupport.java
@@ -238,11 +238,11 @@ public final class DISMSupport
         }
     }
     /**
-     * Calculates the points for DELAY, WITHDRAW, DISENGAGE, WDRAWUP, RETIRE, FPOL, RPOL
+     * Calculates the points for line24 and line33 (DELAY, WITHDRAW, DISENGAGE, WDRAWUP, RETIRE, FPOL, RPOL, PURSUIT)
      *
      * @param points OUT - the client points, also used for the returned points.
      */
-    protected static int GetDelayGraphicEtcDouble(POINT2[] points) {
+    protected static int GetDelayGraphicEtcDouble(POINT2[] points, int lineType) {
         int counter=0;
         try {
             POINT2[] savepoints = new POINT2[3];
@@ -259,97 +259,8 @@ public final class DISMSupport
             POINT2[] deltapoints = new POINT2[4];
             int j = 0;
 
-            for (j = 0; j < 3; j++) {
-                savepoints[j] = new POINT2(points[j]);
-            }
-
-            lineutility.InitializePOINT2Array(arcpoints);
-            lineutility.InitializePOINT2Array(deltapoints);
-
-            points[counter] = new POINT2(savepoints[0]);
-            points[counter].style = 14;
-            counter++;
-            points[counter] = new POINT2(savepoints[1]);
-            points[counter].style = 5;
-            counter++;
-
-            iLength =  Math.sqrt((savepoints[1].x - savepoints[0].x) * (savepoints[1].x - savepoints[0].x) +
-                    (savepoints[1].y - savepoints[0].y) * (savepoints[1].y - savepoints[0].y));
-            iRadius =  Math.sqrt((savepoints[2].x - savepoints[1].x) * (savepoints[2].x - savepoints[1].x) +
-                    (savepoints[2].y - savepoints[1].y) * (savepoints[2].y - savepoints[1].y)) / 2;
-            iDiagEOL_length = (iLength + iRadius * 2) / 20;           
-
-            double DPIScaleFactor = RendererSettings.getInstance().getDeviceDPI() / 96.0;
-            if ((double) iDiagEOL_length > maxLength * DPIScaleFactor) {
-                iDiagEOL_length = maxLength * DPIScaleFactor;
-            }
-            if ((double) iDiagEOL_length < minLength * DPIScaleFactor) {   //was minLength
-                iDiagEOL_length = minLength * DPIScaleFactor;
-            }
-                        
-            dAngle1 = Math.atan2(points[1].y - points[0].y, points[1].x - points[0].x);
-
-            iDeltaX1 = (iDiagEOL_length * Math.cos(dAngle1 - CONST_PI / 4));
-            iDeltaY1 = (iDiagEOL_length * Math.sin(dAngle1 - CONST_PI / 4));
-            iDeltaX2 = (iDiagEOL_length * Math.cos(dAngle1 + CONST_PI / 4));
-            iDeltaY2 = (iDiagEOL_length * Math.sin(dAngle1 + CONST_PI / 4));
-            DrawEndpieceDeltasDouble(savepoints[0],
-                    iDeltaX1, iDeltaY1, iDeltaX2, iDeltaY2, deltapoints);
-
-
-            for (j = 0; j < 4; j++) {
-                points[counter] = new POINT2(deltapoints[j]);
-                counter++;
-            }
-            // draw the semicircle
-            ptArcCenter.x = (savepoints[1].x + savepoints[2].x) / 2;
-            ptArcCenter.y = (savepoints[1].y + savepoints[2].y) / 2;
-
-
-            boolean reverseArc = ReverseDelayArc(savepoints);
-            if (reverseArc == false) {
-                ArcApproximationDouble( (ptArcCenter.x - iRadius), (ptArcCenter.y - iRadius),
-                        (ptArcCenter.x + iRadius), (ptArcCenter.y + iRadius),
-                        savepoints[1].x, savepoints[1].y, savepoints[2].x, savepoints[2].y, arcpoints);
-            } else {
-                ArcApproximationDouble((ptArcCenter.x - iRadius), (ptArcCenter.y - iRadius),
-                        (ptArcCenter.x + iRadius), (ptArcCenter.y + iRadius),
-                        savepoints[2].x, savepoints[2].y, savepoints[1].x, savepoints[1].y, arcpoints);
-            }
-
-            for (j = 0; j < 17; j++) {
-                points[counter] = new POINT2(arcpoints[j]);
-                points[counter].style = 0;
-                counter++;
-            }
-
-        } catch (Exception exc) {
-            ErrorLogger.LogException(_className ,"GetDelayGraphicEtcDouble",
-                    new RendererException("Failed inside GetDelayGraphicEtcDouble", exc));
-        }
-        return counter;
-    }
-    /**
-     * Calculates the points for PURSUIT
-     *
-     * @param points OUT - the client points, also used for the returned points.
-     */
-    protected static int GetPursuitGraphicDouble(POINT2[] points) {
-        int counter=0;
-        try {
-            POINT2[] savepoints = new POINT2[3];
-            double iLength = 0;
-            double iRadius = 0;
-            double iDiagEOL_length = 0;
-            double dAngle1 = 0;
-            double iDeltaX1 = 0;
-            double iDeltaY1 = 0;
-            double iDeltaX2 = 0;
-            double iDeltaY2 = 0;
-            POINT2 ptArcCenter = new POINT2();
-            POINT2[] arcpoints = new POINT2[17];
-            POINT2[] deltapoints = new POINT2[4];
-            int j = 0;
+            // Make arc perpendicular to line
+            points[2] = lineutility.PointRelativeToLine(points[0], points[1], points[1], points[2]);
 
             for (j = 0; j < 3; j++) {
                 savepoints[j] = new POINT2(points[j]);
@@ -365,12 +276,15 @@ public final class DISMSupport
             points[counter].style = 5;
             counter++;
 
-            iLength =  Math.sqrt((savepoints[1].x - savepoints[0].x) * (savepoints[1].x - savepoints[0].x) +
+            iLength = Math.sqrt((savepoints[1].x - savepoints[0].x) * (savepoints[1].x - savepoints[0].x) +
                     (savepoints[1].y - savepoints[0].y) * (savepoints[1].y - savepoints[0].y));
-            iRadius =  Math.sqrt((savepoints[2].x - savepoints[1].x) * (savepoints[2].x - savepoints[1].x) +
+            iRadius = Math.sqrt((savepoints[2].x - savepoints[1].x) * (savepoints[2].x - savepoints[1].x) +
                     (savepoints[2].y - savepoints[1].y) * (savepoints[2].y - savepoints[1].y)) / 2;
             iDiagEOL_length = (iLength + iRadius * 2) / 20;
-            dAngle1 = Math.atan2(points[2].y - points[1].y, points[2].x - points[1].x);
+            if (lineType == TacticalLines.PURSUIT)
+                dAngle1 = Math.atan2(points[2].y - points[1].y, points[2].x - points[1].x);
+            else
+                dAngle1 = Math.atan2(points[1].y - points[0].y, points[1].x - points[0].x);
 
             double DPIScaleFactor = RendererSettings.getInstance().getDeviceDPI() / 96.0;
             if ((double) iDiagEOL_length > maxLength * DPIScaleFactor) {
@@ -388,12 +302,14 @@ public final class DISMSupport
                 ArcApproximationDouble( (ptArcCenter.x - iRadius), (ptArcCenter.y - iRadius),
                         (ptArcCenter.x + iRadius), (ptArcCenter.y + iRadius),
                         savepoints[1].x, savepoints[1].y, savepoints[2].x, savepoints[2].y, arcpoints);
-                dAngle1 += CONST_PI / 2;
+                if (lineType == TacticalLines.PURSUIT)
+                    dAngle1 += CONST_PI / 2;
             } else {
-                dAngle1 -= CONST_PI / 2;
                 ArcApproximationDouble((ptArcCenter.x - iRadius), (ptArcCenter.y - iRadius),
                         (ptArcCenter.x + iRadius), (ptArcCenter.y + iRadius),
                         savepoints[2].x, savepoints[2].y, savepoints[1].x, savepoints[1].y, arcpoints);
+                if (lineType == TacticalLines.PURSUIT)
+                    dAngle1 -= CONST_PI / 2;
             }
 
             // draw the arrow
@@ -401,8 +317,12 @@ public final class DISMSupport
             iDeltaY1 = (iDiagEOL_length * Math.sin(dAngle1 - CONST_PI / 4));
             iDeltaX2 = (iDiagEOL_length * Math.cos(dAngle1 + CONST_PI / 4));
             iDeltaY2 = (iDiagEOL_length * Math.sin(dAngle1 + CONST_PI / 4));
-            DrawEndpieceDeltasDouble(savepoints[2],
-                    iDeltaX1, iDeltaY1, iDeltaX2, iDeltaY2, deltapoints);
+            if (lineType == TacticalLines.PURSUIT)
+                DrawEndpieceDeltasDouble(savepoints[2],
+                        iDeltaX1, iDeltaY1, iDeltaX2, iDeltaY2, deltapoints);
+            else
+                DrawEndpieceDeltasDouble(savepoints[0],
+                        iDeltaX1, iDeltaY1, iDeltaX2, iDeltaY2, deltapoints);
 
             for (j = 0; j < 4; j++) {
                 points[counter] = new POINT2(deltapoints[j]);
@@ -416,14 +336,16 @@ public final class DISMSupport
             }
             points[counter-1].style = 5;
 
-            // draw the line perpendicular to arrow
-            points[counter] = lineutility.ExtendAlongLineDouble(savepoints[1], savepoints[2], iRadius * 2 - iDiagEOL_length, 0);
-            counter++;
-            points[counter] = lineutility.ExtendAlongLineDouble(savepoints[1], savepoints[2], iRadius * 2 + iDiagEOL_length, 0);
-            counter++;
+            if (lineType == TacticalLines.PURSUIT) {
+                // draw the line perpendicular to arrow
+                points[counter] = lineutility.ExtendAlongLineDouble(savepoints[1], savepoints[2], iRadius * 2 - iDiagEOL_length, 0);
+                counter++;
+                points[counter] = lineutility.ExtendAlongLineDouble(savepoints[1], savepoints[2], iRadius * 2 + iDiagEOL_length, 0);
+                counter++;
+            }
         } catch (Exception exc) {
-            ErrorLogger.LogException(_className ,"GetPursuitGraphicDouble",
-                    new RendererException("Failed inside GetPursuitGraphicDouble", exc));
+            ErrorLogger.LogException(_className ,"GetDelayGraphicEtcDouble",
+                    new RendererException("Failed inside GetDelayGraphicEtcDouble", exc));
         }
         return counter;
     }

--- a/renderer/src/main/java/armyc2/c5isr/JavaLineArray/DISMSupport.java
+++ b/renderer/src/main/java/armyc2/c5isr/JavaLineArray/DISMSupport.java
@@ -2310,35 +2310,38 @@ public final class DISMSupport
             }
             points[counter - 3].style = 5;
             points[counter - 1].style = 5;
+
             // draw the arrowhead on line between savepoints 2 and 3
-            pts[0] = new POINT2(savepoints[2]);
-            pts[1] = new POINT2(savepoints[3]);
-            iLengthPt2Pt3 =  Math.sqrt((pts[1].x - pts[0].x) * (pts[1].x - pts[0].x) +
-                    (pts[1].y - pts[0].y) * (pts[1].y - pts[0].y));
-            iDiagEOL_length = iLengthPt2Pt3 / 8;
+            if (linetype != TacticalLines.MOBILE_DEFENSE) {
+                pts[0] = new POINT2(savepoints[2]);
+                pts[1] = new POINT2(savepoints[3]);
+                iLengthPt2Pt3 =  Math.sqrt((pts[1].x - pts[0].x) * (pts[1].x - pts[0].x) +
+                        (pts[1].y - pts[0].y) * (pts[1].y - pts[0].y));
+                iDiagEOL_length = iLengthPt2Pt3 / 8;
 
-            //M. Deutch 8-19-04
-            if (iDiagEOL_length >  maxLength * DPIScaleFactor) {
-                iDiagEOL_length =  maxLength * DPIScaleFactor;
-            }
-            if (iDiagEOL_length <  minLength * DPIScaleFactor) {
-                iDiagEOL_length =  minLength * DPIScaleFactor;
-            }
+                //M. Deutch 8-19-04
+                if (iDiagEOL_length >  maxLength * DPIScaleFactor) {
+                    iDiagEOL_length =  maxLength * DPIScaleFactor;
+                }
+                if (iDiagEOL_length <  minLength * DPIScaleFactor) {
+                    iDiagEOL_length =  minLength * DPIScaleFactor;
+                }
 
-            dAngle1 = Math.atan2(pts[1].y - pts[0].y, pts[1].x - pts[0].x);
-            iDeltaX1 =  (iDiagEOL_length * Math.cos(dAngle1 - CONST_PI / 4));
-            iDeltaY1 =  (iDiagEOL_length * Math.sin(dAngle1 - CONST_PI / 4));
-            iDeltaX2 =  (iDiagEOL_length * Math.cos(dAngle1 + CONST_PI / 4));
-            iDeltaY2 =  (iDiagEOL_length * Math.sin(dAngle1 + CONST_PI / 4));
-            DrawEndpieceDeltasDouble(pts[0],
-                    iDeltaX1, iDeltaY1, iDeltaX2, iDeltaY2, deltapoints);
-            for (j = 0; j < 4; j++) {
-                points[counter] = new POINT2(deltapoints[j]);
-                points[counter].style = 0;
-                counter++;
+                dAngle1 = Math.atan2(pts[1].y - pts[0].y, pts[1].x - pts[0].x);
+                iDeltaX1 =  (iDiagEOL_length * Math.cos(dAngle1 - CONST_PI / 4));
+                iDeltaY1 =  (iDiagEOL_length * Math.sin(dAngle1 - CONST_PI / 4));
+                iDeltaX2 =  (iDiagEOL_length * Math.cos(dAngle1 + CONST_PI / 4));
+                iDeltaY2 =  (iDiagEOL_length * Math.sin(dAngle1 + CONST_PI / 4));
+                DrawEndpieceDeltasDouble(pts[0],
+                        iDeltaX1, iDeltaY1, iDeltaX2, iDeltaY2, deltapoints);
+                for (j = 0; j < 4; j++) {
+                    points[counter] = new POINT2(deltapoints[j]);
+                    points[counter].style = 0;
+                    counter++;
+                }
+                points[counter - 3].style = 5;
+                points[counter - 1].style = 5;
             }
-            points[counter - 3].style = 5;
-            points[counter - 1].style = 5;
 
             // draw the semicircle
             iRadius =  (Math.sqrt((savepoints[2].x - savepoints[1].x) * (savepoints[2].x - savepoints[1].x) +

--- a/renderer/src/main/java/armyc2/c5isr/JavaLineArray/DISMSupport.java
+++ b/renderer/src/main/java/armyc2/c5isr/JavaLineArray/DISMSupport.java
@@ -894,7 +894,7 @@ public final class DISMSupport
                 for (j = 0; j < 3; j++) {
                     points[counter] = new POINT2(ptsJaggyLine[j]);
                     points[counter].style = 0;
-                    if(linetype==TacticalLines.SARA)
+                    if(linetype==TacticalLines.SARA || linetype==TacticalLines.MOVEMENT_TO_CONTACT)
                     {
                         points[counter].style = 9;
                     }
@@ -903,7 +903,7 @@ public final class DISMSupport
                 }
 
                 points[counter - 1].style = 5;
-                if(linetype==TacticalLines.SARA)
+                if(linetype==TacticalLines.SARA || linetype==TacticalLines.MOVEMENT_TO_CONTACT)
                 {
                     points[counter-1].style = 9;
                     points[counter]=new POINT2(points[counter-3]);
@@ -979,13 +979,13 @@ public final class DISMSupport
                 {
                     points[counter] = new POINT2(ptsJaggyLine[j]);
                     points[counter].style = 0;
-                    if(linetype==TacticalLines.SARA)
+                    if(linetype==TacticalLines.SARA || linetype==TacticalLines.MOVEMENT_TO_CONTACT)
                         points[counter].style = 9;
 
                     counter++;
                 }
                 points[counter - 1].style = 5;
-                if(linetype==TacticalLines.SARA)
+                if(linetype==TacticalLines.SARA || linetype==TacticalLines.MOVEMENT_TO_CONTACT)
                 {
                     points[counter-1].style = 9;
                     points[counter]=new POINT2(points[counter-3]);

--- a/renderer/src/main/java/armyc2/c5isr/JavaLineArray/DISMSupport.java
+++ b/renderer/src/main/java/armyc2/c5isr/JavaLineArray/DISMSupport.java
@@ -357,13 +357,13 @@ public final class DISMSupport
             }
 
             POINT2[] ptsSeize = new POINT2[2];
-            ptsSeize[0] = new POINT2(pPoints[0]);
+            ptsSeize[0] = new POINT2(pPoints[1]);
             ptsSeize[1] = new POINT2(pPoints[2]);
             lineutility.CalcClockwiseCenterDouble(ptsSeize);
             double d = lineutility.CalcDistanceDouble(ptsSeize[0], pPoints[3]);
 
             ptsSeize[0] = new POINT2(pPoints[2]);
-            ptsSeize[1] = new POINT2(pPoints[0]);
+            ptsSeize[1] = new POINT2(pPoints[1]);
             lineutility.CalcClockwiseCenterDouble(ptsSeize);
             double dArcReversed = lineutility.CalcDistanceDouble(ptsSeize[0], pPoints[3]);
 
@@ -428,15 +428,15 @@ public final class DISMSupport
             ptArcCenter.x = (points[1].x + points[2].x) / 2;
             ptArcCenter.y = (points[1].y + points[2].y) / 2;
             if (reverseArc) {
-                ArcApproximationDouble( (ptArcCenter.x - iRadius), (ptArcCenter.y - iRadius),
+                ArcApproximationDouble((ptArcCenter.x - iRadius), (ptArcCenter.y - iRadius),
                         (ptArcCenter.x + iRadius), (ptArcCenter.y + iRadius),
                         points[1].x, points[1].y, points[2].x, points[2].y, arcpoints);
                 dAngle1 += CONST_PI / 2;
             } else {
-                dAngle1 -= CONST_PI / 2;
                 ArcApproximationDouble((ptArcCenter.x - iRadius), (ptArcCenter.y - iRadius),
                         (ptArcCenter.x + iRadius), (ptArcCenter.y + iRadius),
                         points[2].x, points[2].y, points[1].x, points[1].y, arcpoints);
+                dAngle1 -= CONST_PI / 2;
             }
 
             // draw the arrow

--- a/renderer/src/main/java/armyc2/c5isr/JavaLineArray/DISMSupport.java
+++ b/renderer/src/main/java/armyc2/c5isr/JavaLineArray/DISMSupport.java
@@ -238,14 +238,13 @@ public final class DISMSupport
         }
     }
     /**
-     * Calculates the points for DELAY, WITHDRAW, WDRAWUP, RETIRE
+     * Calculates the points for DELAY, WITHDRAW, DISENGAGE, WDRAWUP, RETIRE, FPOL, RPOL
      *
      * @param points OUT - the client points, also used for the returned points.
      */
     protected static int GetDelayGraphicEtcDouble(POINT2[] points) {
         int counter=0;
         try {
-            POINT2[] pts = new POINT2[2];
             POINT2[] savepoints = new POINT2[3];
             double iLength = 0;
             double iRadius = 0;
@@ -264,7 +263,6 @@ public final class DISMSupport
                 savepoints[j] = new POINT2(points[j]);
             }
 
-            lineutility.InitializePOINT2Array(pts);
             lineutility.InitializePOINT2Array(arcpoints);
             lineutility.InitializePOINT2Array(deltapoints);
 
@@ -328,6 +326,104 @@ public final class DISMSupport
         } catch (Exception exc) {
             ErrorLogger.LogException(_className ,"GetDelayGraphicEtcDouble",
                     new RendererException("Failed inside GetDelayGraphicEtcDouble", exc));
+        }
+        return counter;
+    }
+    /**
+     * Calculates the points for PURSUIT
+     *
+     * @param points OUT - the client points, also used for the returned points.
+     */
+    protected static int GetPursuitGraphicDouble(POINT2[] points) {
+        int counter=0;
+        try {
+            POINT2[] savepoints = new POINT2[3];
+            double iLength = 0;
+            double iRadius = 0;
+            double iDiagEOL_length = 0;
+            double dAngle1 = 0;
+            double iDeltaX1 = 0;
+            double iDeltaY1 = 0;
+            double iDeltaX2 = 0;
+            double iDeltaY2 = 0;
+            POINT2 ptArcCenter = new POINT2();
+            POINT2[] arcpoints = new POINT2[17];
+            POINT2[] deltapoints = new POINT2[4];
+            int j = 0;
+
+            for (j = 0; j < 3; j++) {
+                savepoints[j] = new POINT2(points[j]);
+            }
+
+            lineutility.InitializePOINT2Array(arcpoints);
+            lineutility.InitializePOINT2Array(deltapoints);
+
+            points[counter] = new POINT2(savepoints[0]);
+            points[counter].style = 14;
+            counter++;
+            points[counter] = new POINT2(savepoints[1]);
+            points[counter].style = 5;
+            counter++;
+
+            iLength =  Math.sqrt((savepoints[1].x - savepoints[0].x) * (savepoints[1].x - savepoints[0].x) +
+                    (savepoints[1].y - savepoints[0].y) * (savepoints[1].y - savepoints[0].y));
+            iRadius =  Math.sqrt((savepoints[2].x - savepoints[1].x) * (savepoints[2].x - savepoints[1].x) +
+                    (savepoints[2].y - savepoints[1].y) * (savepoints[2].y - savepoints[1].y)) / 2;
+            iDiagEOL_length = (iLength + iRadius * 2) / 20;
+            dAngle1 = Math.atan2(points[2].y - points[1].y, points[2].x - points[1].x);
+
+            double DPIScaleFactor = RendererSettings.getInstance().getDeviceDPI() / 96.0;
+            if ((double) iDiagEOL_length > maxLength * DPIScaleFactor) {
+                iDiagEOL_length = maxLength * DPIScaleFactor;
+            }
+            if ((double) iDiagEOL_length < minLength * DPIScaleFactor) {   //was minLength
+                iDiagEOL_length = minLength * DPIScaleFactor;
+            }
+
+            // draw the semicircle
+            ptArcCenter.x = (savepoints[1].x + savepoints[2].x) / 2;
+            ptArcCenter.y = (savepoints[1].y + savepoints[2].y) / 2;
+            boolean reverseArc = ReverseDelayArc(savepoints);
+            if (reverseArc == false) {
+                ArcApproximationDouble( (ptArcCenter.x - iRadius), (ptArcCenter.y - iRadius),
+                        (ptArcCenter.x + iRadius), (ptArcCenter.y + iRadius),
+                        savepoints[1].x, savepoints[1].y, savepoints[2].x, savepoints[2].y, arcpoints);
+                dAngle1 += CONST_PI / 2;
+            } else {
+                dAngle1 -= CONST_PI / 2;
+                ArcApproximationDouble((ptArcCenter.x - iRadius), (ptArcCenter.y - iRadius),
+                        (ptArcCenter.x + iRadius), (ptArcCenter.y + iRadius),
+                        savepoints[2].x, savepoints[2].y, savepoints[1].x, savepoints[1].y, arcpoints);
+            }
+
+            // draw the arrow
+            iDeltaX1 = (iDiagEOL_length * Math.cos(dAngle1 - CONST_PI / 4));
+            iDeltaY1 = (iDiagEOL_length * Math.sin(dAngle1 - CONST_PI / 4));
+            iDeltaX2 = (iDiagEOL_length * Math.cos(dAngle1 + CONST_PI / 4));
+            iDeltaY2 = (iDiagEOL_length * Math.sin(dAngle1 + CONST_PI / 4));
+            DrawEndpieceDeltasDouble(savepoints[2],
+                    iDeltaX1, iDeltaY1, iDeltaX2, iDeltaY2, deltapoints);
+
+            for (j = 0; j < 4; j++) {
+                points[counter] = new POINT2(deltapoints[j]);
+                counter++;
+            }
+
+            for (j = 0; j < 17; j++) {
+                points[counter] = new POINT2(arcpoints[j]);
+                points[counter].style = 0;
+                counter++;
+            }
+            points[counter-1].style = 5;
+
+            // draw the line perpendicular to arrow
+            points[counter] = lineutility.ExtendAlongLineDouble(savepoints[1], savepoints[2], iRadius * 2 - iDiagEOL_length, 0);
+            counter++;
+            points[counter] = lineutility.ExtendAlongLineDouble(savepoints[1], savepoints[2], iRadius * 2 + iDiagEOL_length, 0);
+            counter++;
+        } catch (Exception exc) {
+            ErrorLogger.LogException(_className ,"GetPursuitGraphicDouble",
+                    new RendererException("Failed inside GetPursuitGraphicDouble", exc));
         }
         return counter;
     }

--- a/renderer/src/main/java/armyc2/c5isr/JavaLineArray/DISMSupport.java
+++ b/renderer/src/main/java/armyc2/c5isr/JavaLineArray/DISMSupport.java
@@ -55,7 +55,7 @@ public final class DISMSupport
         }
         return result;
     }
-    private static void ArcApproximationDouble(double left, double top, double right, double bottom,
+    protected static void ArcApproximationDouble(double left, double top, double right, double bottom,
             double startx, double starty, double endx, double endy, POINT2[] lpoints)
     {
 

--- a/renderer/src/main/java/armyc2/c5isr/JavaLineArray/DISMSupport.java
+++ b/renderer/src/main/java/armyc2/c5isr/JavaLineArray/DISMSupport.java
@@ -383,7 +383,6 @@ public final class DISMSupport
     protected static int GetEnvelopmentGraphicDouble(POINT2[] points) {
         int counter=0;
         try {
-            POINT2[] savepoints = new POINT2[4];
             double iLength = 0;
             double iRadius = 0;
             double iDiagEOL_length = 0;
@@ -397,19 +396,18 @@ public final class DISMSupport
             POINT2[] deltapoints = new POINT2[4];
             int j = 0;
 
-            for (j = 0; j < 4; j++) {
-                savepoints[j] = new POINT2(points[j]);
-            }
-
             lineutility.InitializePOINT2Array(arcpoints);
             lineutility.InitializePOINT2Array(deltapoints);
 
-            points[0] = new POINT2(savepoints[0]);
+            boolean reverseArc = IsEnvelopmentArcReversed(points);
+
             points[0].style = 14;
             counter++;
-            points[1] = lineutility.ClosestPointOnLine(savepoints[0], savepoints[2], savepoints[1]);
             points[1].style = 5;
             counter++;
+
+            // Place pt3 on line pt1pt2
+            points[2] = lineutility.ClosestPointOnLine(points[0], lineutility.ExtendLine2Double(points[0], points[1], lineutility.CalcDistanceDouble(points[1], points[2]), 0), points[2]);
 
             iLength =  Math.sqrt((points[1].x - points[0].x) * (points[1].x - points[0].x) +
                     (points[1].y - points[0].y) * (points[1].y - points[0].y));
@@ -419,27 +417,26 @@ public final class DISMSupport
             dAngle1 = Math.atan2(points[2].y - points[1].y, points[2].x - points[1].x);
 
             double DPIScaleFactor = RendererSettings.getInstance().getDeviceDPI() / 96.0;
-            if ((double) iDiagEOL_length > maxLength * DPIScaleFactor) {
+            if (iDiagEOL_length > maxLength * DPIScaleFactor) {
                 iDiagEOL_length = maxLength * DPIScaleFactor;
             }
-            if ((double) iDiagEOL_length < minLength * DPIScaleFactor) {   //was minLength
+            if (iDiagEOL_length < minLength * DPIScaleFactor) {   //was minLength
                 iDiagEOL_length = minLength * DPIScaleFactor;
             }
 
             // draw the semicircle
-            ptArcCenter.x = (points[1].x + savepoints[2].x) / 2;
-            ptArcCenter.y = (points[1].y + savepoints[2].y) / 2;
-            boolean reverseArc = IsEnvelopmentArcReversed(savepoints);
+            ptArcCenter.x = (points[1].x + points[2].x) / 2;
+            ptArcCenter.y = (points[1].y + points[2].y) / 2;
             if (reverseArc) {
                 ArcApproximationDouble( (ptArcCenter.x - iRadius), (ptArcCenter.y - iRadius),
                         (ptArcCenter.x + iRadius), (ptArcCenter.y + iRadius),
-                        points[1].x, points[1].y, savepoints[2].x, savepoints[2].y, arcpoints);
+                        points[1].x, points[1].y, points[2].x, points[2].y, arcpoints);
                 dAngle1 += CONST_PI / 2;
             } else {
                 dAngle1 -= CONST_PI / 2;
                 ArcApproximationDouble((ptArcCenter.x - iRadius), (ptArcCenter.y - iRadius),
                         (ptArcCenter.x + iRadius), (ptArcCenter.y + iRadius),
-                        savepoints[2].x, savepoints[2].y, points[1].x, points[1].y, arcpoints);
+                        points[2].x, points[2].y, points[1].x, points[1].y, arcpoints);
             }
 
             // draw the arrow
@@ -447,7 +444,7 @@ public final class DISMSupport
             iDeltaY1 = (iDiagEOL_length * Math.sin(dAngle1 - CONST_PI / 4));
             iDeltaX2 = (iDiagEOL_length * Math.cos(dAngle1 + CONST_PI / 4));
             iDeltaY2 = (iDiagEOL_length * Math.sin(dAngle1 + CONST_PI / 4));
-            DrawEndpieceDeltasDouble(savepoints[2],
+            DrawEndpieceDeltasDouble(points[2],
                     iDeltaX1, iDeltaY1, iDeltaX2, iDeltaY2, deltapoints);
 
             for (j = 0; j < 4; j++) {

--- a/renderer/src/main/java/armyc2/c5isr/JavaLineArray/TacticalLines.java
+++ b/renderer/src/main/java/armyc2/c5isr/JavaLineArray/TacticalLines.java
@@ -498,5 +498,19 @@ public final class TacticalLines {
     public static final int ROUTE = 25330500;
     public static final int FPOL = 25344100;
     public static final int RPOL = 25344200;
+
+    public static final int AREA_DEFENSE = 25152600;
+    public static final int FRONTAL_ATTACK = 25152700;
+    public static final int TURNING_MOVEMENT = 25152900;
+    public static final int MOBILE_DEFENSE = 25152800;
+    public static final int KILL_ZONE = 25242800;
+    public static final int MOVEMENT_TO_CONTACT = 25342900;
+    public static final int EXPLOIT = 25343100;
+    public static final int DEMONSTRATE = 25343300;
+    public static final int ENVELOPMENT = 25343500;
+    public static final int INFILTRATION = 25343800;
+    public static final int PURSUIT = 25344000;
+    public static final int DISENGAGE = 25344400;
+    public static final int EVACUATE = 25344500;
 }
 

--- a/renderer/src/main/java/armyc2/c5isr/JavaLineArray/TacticalLines.java
+++ b/renderer/src/main/java/armyc2/c5isr/JavaLineArray/TacticalLines.java
@@ -40,6 +40,7 @@ public final class TacticalLines {
     public static final int WEZ = 25171300;
     public static final int FEZ = 25171400;
     public static final int JEZ = 25171500;
+    public static final int WFZ_REVD = 2517200;
     public static final int WFZ = 22235000;
     public static final int EZ = 22136000;
     public static final int AIRFIELD = 221311000;

--- a/renderer/src/main/java/armyc2/c5isr/JavaLineArray/arraysupport.java
+++ b/renderer/src/main/java/armyc2/c5isr/JavaLineArray/arraysupport.java
@@ -3447,6 +3447,160 @@ public final class arraysupport {
                     }
                     acCounter = vblCounter;
                     break;
+                case TacticalLines.INFILTRATION:
+                    // Move pt1 into rectangle between pt1 and pt2
+                    if (pt1.y < pt0.y && pt1.y < pt2.y)
+                        pt1.y = Math.min(pt0.y, pt2.y);
+                    else if (pt1.y > pt0.y && pt1.y > pt2.y)
+                        pt1.y = Math.max(pt0.y, pt2.y);
+                    if (pt1.x < pt0.x && pt1.x < pt2.x)
+                        pt1.x = Math.min(pt0.x, pt2.x);
+                    else if (pt1.x > pt0.x && pt1.x > pt2.x)
+                        pt1.x = Math.max(pt0.x, pt2.x);
+                    dMBR = lineutility.MBRDistance(pLinePoints, vblSaveCounter);
+
+                    lineutility.InitializePOINT2Array(arcPts);
+
+                    if (dMBR / 20 > maxLength * DPIScaleFactor) {
+                        dMBR = 20 * maxLength * DPIScaleFactor;
+                    }
+                    if (dMBR / 20 < minLength * DPIScaleFactor) {
+                        dMBR = 20 * minLength * DPIScaleFactor;
+                    }
+                    if (dMBR < 150 * DPIScaleFactor) {
+                        dMBR = 150 * DPIScaleFactor;
+                    }
+                    if (dMBR > 500 * DPIScaleFactor) {
+                        dMBR = 500 * DPIScaleFactor;
+                    }
+
+                    // Add control points
+                    pLinePoints[0] = pt0;
+                    pLinePoints[18] = pt1;
+                    pLinePoints[36] = pt2;
+
+                    // Add arrow
+                    lineutility.GetArrowHead4Double(new POINT2(pt0.x, pt2.y), pt2, (int) dMBR / 20, (int) dMBR / 20, pArrowPoints, 0);
+                    for (k = 0; k < 3; k++) {
+                        pLinePoints[vblCounter - k - 1] = new POINT2(pArrowPoints[k]);
+                    }
+
+                    // Add curves
+                    if (pt0.y > pt2.y && pt0.x > pt2.x) { // pt0 is bottom right
+                        if (pt1.x < pt0.x) {
+                            dRadius = pt0.y - pt1.y;
+                            DISMSupport.ArcApproximationDouble(pt1.x, pt0.y - 2 * dRadius, Math.min(pt1.x + 2 * dRadius, pt1.x + 2 * (pt0.x - pt1.x)), pt0.y,
+                                    pt1.x, pt1.y, Math.min(pt1.x + dRadius, pt0.x), pt0.y,
+                                    arcPts);
+                            for (k = 0; k < 17; k++) {
+                                pLinePoints[k + 1] = new POINT2(arcPts[16 - k]);
+                            }
+                        } else {
+                            for (k = 0; k < 17; k++) {
+                                pLinePoints[k + 1] = new POINT2(pt1);
+                            }
+                        }
+
+                        if (pt2.x < pt1.x) {
+                            dRadius = pt1.y - pt2.y;
+                            DISMSupport.ArcApproximationDouble(Math.max(pt1.x - 2 * dRadius, pt1.x - 2 * (pt1.x - pt2.x)), pt2.y, pt1.x, pt2.y + dRadius * 2,
+                                    pt1.x, pt1.y, Math.max(pt1.x - dRadius, pt2.x), pt2.y,
+                                    arcPts);
+                            for (k = 0; k < 17; k++) {
+                                pLinePoints[k + 19] = new POINT2(arcPts[k]);
+                            }
+                        } else {
+                            for (k = 0; k < 17; k++) {
+                                pLinePoints[k + 19] = new POINT2(pt1);
+                            }
+                        }
+                    } else if (pt0.y > pt2.y && pt0.x < pt2.x) { // pt0 is bottom left
+                        if (pt0.x < pt1.x) {
+                            dRadius = pt0.y - pt1.y;
+                            DISMSupport.ArcApproximationDouble(Math.max(pt1.x - 2 * dRadius, pt1.x - 2 * (pt1.x - pt0.x)), pt0.y - dRadius * 2, pt1.x, pt0.y,
+                                    Math.max(pt1.x - dRadius, pt0.x), pt0.y, pt1.x, pt1.y,
+                                    arcPts);
+                            for (k = 0; k < 17; k++) {
+                                pLinePoints[k + 1] = new POINT2(arcPts[k]);
+                            }
+                        } else {
+                            for (k = 0; k < 17; k++) {
+                                pLinePoints[k + 1] = new POINT2(pt1);
+                            }
+                        }
+
+                        if (pt1.x < pt2.x) {
+                            dRadius = pt1.y - pt2.y;
+                            DISMSupport.ArcApproximationDouble(pt1.x, pt2.y, Math.min(pt1.x + 2 * dRadius, pt1.x + 2 * (pt2.x - pt1.x)), pt2.y + 2 * dRadius,
+                                    Math.min(pt1.x + dRadius, pt2.x), pt2.y, pt1.x, pt1.y,
+                                    arcPts);
+                            for (k = 0; k < 17; k++) {
+                                pLinePoints[k + 19] = new POINT2(arcPts[16 - k]);
+                            }
+                        } else {
+                            for (k = 0; k < 17; k++) {
+                                pLinePoints[k + 19] = new POINT2(pt1);
+                            }
+                        }
+                    } else if (pt0.y < pt2.y && pt0.x > pt2.x) { // pt0 is top right
+                        if (pt1.x < pt0.x) {
+                            dRadius = pt1.y - pt0.y;
+                            DISMSupport.ArcApproximationDouble(pt1.x, pt0.y, Math.min(pt1.x + 2 * dRadius, pt1.x + 2 * (pt0.x - pt1.x)), pt0.y + 2 * dRadius,
+                                    Math.min(pt1.x + dRadius, pt0.x), pt0.y, pt1.x, pt1.y,
+                                    arcPts);
+                            for (k = 0; k < 17; k++) {
+                                pLinePoints[k + 1] = new POINT2(arcPts[k]);
+                            }
+                        } else {
+                            for (k = 0; k < 17; k++) {
+                                pLinePoints[k + 1] = new POINT2(pt1);
+                            }
+                        }
+
+                        if (pt2.x < pt1.x) {
+                            dRadius = pt2.y - pt1.y;
+                            DISMSupport.ArcApproximationDouble(Math.max(pt1.x - 2 * dRadius, pt1.x - 2 * (pt1.x - pt2.x)), pt2.y - dRadius * 2, pt1.x, pt2.y,
+                                    Math.max(pt1.x - dRadius, pt2.x), pt2.y, pt1.x, pt1.y,
+                                    arcPts);
+                            for (k = 0; k < 17; k++) {
+                                pLinePoints[k + 19] = new POINT2(arcPts[16 - k]);
+                            }
+                        } else {
+                            for (k = 0; k < 17; k++) {
+                                pLinePoints[k + 19] = new POINT2(pt1);
+                            }
+                        }
+                    } else { // if (pt0.y < pt2.y && pt0.x < pt2.x) { // pt0 is top left
+                        if (pt0.x < pt1.x) {
+                            dRadius = pt1.y - pt0.y;
+                            DISMSupport.ArcApproximationDouble(Math.max(pt1.x - 2 * dRadius, pt1.x - 2 * (pt1.x - pt0.x)), pt0.y, pt1.x, pt0.y + dRadius * 2,
+                                    pt1.x, pt1.y, Math.max(pt1.x - dRadius, pt0.x), pt0.y,
+                                    arcPts);
+                            for (k = 0; k < 17; k++) {
+                                pLinePoints[k + 1] = new POINT2(arcPts[16 - k]);
+                            }
+                        } else {
+                            for (k = 0; k < 17; k++) {
+                                pLinePoints[k + 1] = new POINT2(pt1);
+                            }
+                        }
+
+                        if (pt1.x < pt2.x) {
+                            dRadius = pt2.y - pt1.y;
+                            DISMSupport.ArcApproximationDouble(pt1.x, pt2.y - 2 * dRadius, Math.min(pt1.x + 2 * dRadius, pt1.x + 2 * (pt2.x - pt1.x)), pt2.y,
+                                    pt1.x, pt1.y, Math.min(pt1.x + dRadius, pt2.x), pt2.y,
+                                    arcPts);
+                            for (k = 0; k < 17; k++) {
+                                pLinePoints[k + 19] = new POINT2(arcPts[k]);
+                            }
+                        } else {
+                            for (k = 0; k < 17; k++) {
+                                pLinePoints[k + 19] = new POINT2(pt1);
+                            }
+                        }
+                    }
+                    acCounter = vblCounter;
+                    break;
                 case TacticalLines.EXPLOIT:
                     // Convert arrows to 90 degrees with the hypotenuse distance = distance between pt1 and pt2
                     int triBiSector = (int) (lineutility.CalcDistanceDouble(pt1, pt2) / Math.sqrt(2));
@@ -4022,6 +4176,7 @@ public final class arraysupport {
                 case TacticalLines.ABATIS:
                 case TacticalLines.MOBILE_DEFENSE:
                 case TacticalLines.ENVELOPMENT:
+                case TacticalLines.INFILTRATION:
                     FillPoints(pLinePoints, acCounter, points);
                     break;
                 default:
@@ -4727,6 +4882,7 @@ public final class arraysupport {
                     addPolyline(secondPoly, 9, shapes); // Arrow and bowtie
                     break;
                 case TacticalLines.DIRATKSPT:
+                case TacticalLines.INFILTRATION:
                     addPolyline(pLinePoints, acCounter - 3, shapes); // Main line
                     secondPoly = new POINT2[3];
                     for (int i = 0; i < 3; i++) {

--- a/renderer/src/main/java/armyc2/c5isr/JavaLineArray/arraysupport.java
+++ b/renderer/src/main/java/armyc2/c5isr/JavaLineArray/arraysupport.java
@@ -638,7 +638,7 @@ public final class arraysupport {
             int j = 0, k = 0, l = 0;
             POINT2[] ptsArc = new POINT2[26];
             POINT2[] midPts = new POINT2[7];
-            POINT2[] trianglePts = new POINT2[21];
+            POINT2[] trianglePts = new POINT2[35];
             POINT2[] pArrowPoints = new POINT2[3];
             double dRadius = lineutility.CalcDistanceDouble(pt0, pt1);
             double dLength = Math.abs(dRadius - 20);
@@ -731,6 +731,47 @@ public final class arraysupport {
                     pLinePoints[46].style = 5;
                     for (j = 47; j < 50; j++) {
                         pLinePoints[j] = new POINT2(pArrowPoints[j - 47]);
+                        pLinePoints[j].style = 0;
+                    }
+                    break;
+                case TacticalLines.AREA_DEFENSE:
+                    if (dRadius > 100) {
+                        dLength = 0.8 * dRadius;
+                    }
+                    for (j = 1; j <= 23; j++) {
+                        if (j % 3 == 0) {
+                            midPts[k].x = pt0.x - (long) ((dRadius / dLength) * (pt0.x - ptsArc[j].x));
+                            midPts[k].y = pt0.y - (long) ((dRadius / dLength) * (pt0.y - ptsArc[j].y));
+                            trianglePts[l] = new POINT2(ptsArc[j - 1]);
+                            trianglePts[l].style = 9;
+                            l++;
+                            trianglePts[l] = new POINT2(midPts[k]);
+                            trianglePts[l].style = 9;
+                            l++;
+                            trianglePts[l] = new POINT2(ptsArc[j + 1]);
+                            trianglePts[l].style = 9;
+                            l++;
+                            trianglePts[l] = new POINT2(ptsArc[j]);
+                            trianglePts[l].style = 9;
+                            l++;
+                            trianglePts[l] = new POINT2(ptsArc[j - 1]);
+                            trianglePts[l].style = 10;
+                            l++;
+                            k++;
+                        }
+                    }
+                    for (j = 26; j < 61; j++) {
+                        pLinePoints[j] = new POINT2(trianglePts[j - 26]);
+                    }
+                    for (j = 61; j < 64; j++) {
+                        pLinePoints[j] = new POINT2(pArrowPoints[j - 61]);
+                        pLinePoints[j].style = 0;
+                    }
+
+                    lineutility.GetArrowHead4Double(ptsArc[1], ptsArc[0], (int) d / 7, (int) d / 7, pArrowPoints, 0);
+                    pLinePoints[63].style = 5;
+                    for (j = 64; j < 67; j++) {
+                        pLinePoints[j] = new POINT2(pArrowPoints[j - 64]);
                         pLinePoints[j].style = 0;
                     }
                     break;
@@ -2618,6 +2659,10 @@ public final class arraysupport {
                     GetIsolatePointsDouble(pLinePoints, lineType, converter);
                     acCounter = 50;
                     break;
+                case TacticalLines.AREA_DEFENSE:
+                    GetIsolatePointsDouble(pLinePoints, lineType, converter);
+                    acCounter = 67;
+                    break;
                 case TacticalLines.OCCUPY:
                     GetIsolatePointsDouble(pLinePoints, lineType, converter);
                     acCounter = 32;
@@ -3845,6 +3890,7 @@ public final class arraysupport {
                 case TacticalLines.PENETRATE:
                 case TacticalLines.RETAIN:
                 case TacticalLines.SECURE:
+                case TacticalLines.AREA_DEFENSE:
                 case TacticalLines.SEIZE:
                 case TacticalLines.EVACUATE:
                 case TacticalLines.BS_RECTANGLE:
@@ -4638,6 +4684,7 @@ public final class arraysupport {
                 case TacticalLines.MNFLDFIX:
                 case TacticalLines.TURN:
                 case TacticalLines.MNFLDDIS:
+                case TacticalLines.AREA_DEFENSE:
                     //POINT2 initialFillPt=null;
                     for (k = 0; k < acCounter; k++) {
                         if (k == 0) {
@@ -4661,7 +4708,10 @@ public final class arraysupport {
                         if (pLinePoints[k].style == 10) {
                             shape.lineTo(pLinePoints[k]);
                             if (shape != null && shape.getShape() != null) {
-                                shapes.add(0, shape);
+                                if (lineType == TacticalLines.AREA_DEFENSE)
+                                    shapes.add(shape);
+                                else
+                                    shapes.add(0, shape);
                             }
                         }
                     }//end for

--- a/renderer/src/main/java/armyc2/c5isr/JavaLineArray/arraysupport.java
+++ b/renderer/src/main/java/armyc2/c5isr/JavaLineArray/arraysupport.java
@@ -3801,6 +3801,9 @@ public final class arraysupport {
                 case TacticalLines.RPOL:
                     acCounter = DISMSupport.GetDelayGraphicEtcDouble(pLinePoints);
                     break;
+                case TacticalLines.PURSUIT:
+                    acCounter = DISMSupport.GetPursuitGraphicDouble(pLinePoints);
+                    break;
                 case TacticalLines.EASY:
                     acCounter = DISMSupport.GetDISMEasyDouble(pLinePoints, lineType);
                     break;

--- a/renderer/src/main/java/armyc2/c5isr/JavaLineArray/arraysupport.java
+++ b/renderer/src/main/java/armyc2/c5isr/JavaLineArray/arraysupport.java
@@ -3837,6 +3837,101 @@ public final class arraysupport {
                 case TacticalLines.DEMONSTRATE:
                     acCounter = DISMSupport.GetDISMRIPDouble(pLinePoints, lineType);
                     break;
+                case TacticalLines.MOBILE_DEFENSE:
+                    pLinePoints[2] = lineutility.PointRelativeToLine(pt0, pt1, pt1, pt2);
+                    pLinePoints[3] =  lineutility.PointRelativeToLine(pt0, pt1, pt0, pt2);
+                    acCounter = DISMSupport.GetDISMRIPDouble(pLinePoints, lineType);
+                    // Add spikes
+                    POINT2[] trianglePts = new POINT2[18];
+                    lineutility.InitializePOINT2Array(trianglePts);
+                    int l = 0;
+                    dRadius = lineutility.CalcDistanceDouble(pLinePoints[1], pLinePoints[2]) / 2;
+                    POINT2 arcCenter = lineutility.MidPointDouble(pLinePoints[1], pLinePoints[2], 0);
+                    double dLength = Math.abs(dRadius - 20);
+                    if (dRadius < 40) {
+                        dLength = dRadius / 1.5;
+                    }
+                    if (dRadius > 100) {
+                        dLength = 0.8 * dRadius;
+                    }
+
+                    POINT2 tmpPt = new POINT2();
+                    tmpPt.x = arcCenter.x - (long) ((dRadius / dLength) * (arcCenter.x - pLinePoints[10].x));
+                    tmpPt.y = arcCenter.y - (long) ((dRadius / dLength) * (arcCenter.y - pLinePoints[10].y));
+                    trianglePts[l] = new POINT2(pLinePoints[10 - 1]);
+                    trianglePts[l].style = 9;
+                    l++;
+                    trianglePts[l] = new POINT2(tmpPt);
+                    trianglePts[l].style = 9;
+                    l++;
+                    trianglePts[l] = new POINT2(pLinePoints[10 + 1]);
+                    trianglePts[l].style = 9;
+                    l++;
+                    trianglePts[l] = new POINT2(pLinePoints[10]);
+                    trianglePts[l].style = 9;
+                    l++;
+                    trianglePts[l] = new POINT2(pLinePoints[10 - 1]);
+                    trianglePts[l].style = 10;
+                    l++;
+
+                    tmpPt.x = arcCenter.x - (long) ((dRadius / dLength) * (arcCenter.x - pLinePoints[22].x));
+                    tmpPt.y = arcCenter.y - (long) ((dRadius / dLength) * (arcCenter.y - pLinePoints[22].y));
+                    trianglePts[l] = new POINT2(pLinePoints[22 - 1]);
+                    trianglePts[l].style = 9;
+                    l++;
+                    trianglePts[l] = new POINT2(tmpPt);
+                    trianglePts[l].style = 9;
+                    l++;
+                    trianglePts[l] = new POINT2(pLinePoints[22 + 1]);
+                    trianglePts[l].style = 9;
+                    l++;
+                    trianglePts[l] = new POINT2(pLinePoints[22]);
+                    trianglePts[l].style = 9;
+                    l++;
+                    trianglePts[l] = new POINT2(pLinePoints[22 - 1]);
+                    trianglePts[l].style = 10;
+                    l++;
+
+                    double triangleBaseLen = lineutility.CalcDistanceDouble(trianglePts[0], trianglePts[2]);
+                    double triangleHeight = lineutility.CalcDistanceDouble(trianglePts[1], trianglePts[3]);
+                    trianglePts[l] = lineutility.ExtendAlongLineDouble(pLinePoints[3], pLinePoints[2], lineutility.CalcDistanceDouble(pt0, pt1) / 8, 9);
+                    trianglePts[l].style = 9;
+                    l++;
+
+                    trianglePts[l] = lineutility.ExtendAlongLineDouble2(trianglePts[l-1], pLinePoints[2], triangleBaseLen);
+                    trianglePts[l].style = 9;
+                    l++;
+
+                    trianglePts[l] = lineutility.ExtendDirectedLine(trianglePts[l-2], trianglePts[l-1],
+                            lineutility.MidPointDouble(trianglePts[l-2], trianglePts[l-1], 0), lineutility.extend_above, triangleHeight);
+                    trianglePts[l].style = 9;
+                    l++;
+
+                    trianglePts[l] = new POINT2(trianglePts[l-3]);
+                    trianglePts[l].style = 10;
+                    l++;
+
+                    trianglePts[l] = lineutility.ExtendAlongLineDouble(pLinePoints[0], pLinePoints[1], lineutility.CalcDistanceDouble(pt0, pt1) / 8, 9);
+                    trianglePts[l].style = 9;
+                    l++;
+
+                    trianglePts[l] = lineutility.ExtendAlongLineDouble2(trianglePts[l-1], pLinePoints[1], triangleBaseLen);
+                    trianglePts[l].style = 9;
+                    l++;
+
+                    trianglePts[l] = lineutility.ExtendDirectedLine(trianglePts[l-2], trianglePts[l-1],
+                            lineutility.MidPointDouble(trianglePts[l-2], trianglePts[l-1], 0), lineutility.extend_below, triangleHeight);
+                    trianglePts[l].style = 9;
+                    l++;
+
+                    trianglePts[l] = new POINT2(trianglePts[l-3]);
+                    trianglePts[l].style = 10;
+
+                    for (j = 0; j < 18; j++) {
+                        pLinePoints[acCounter] = new POINT2(trianglePts[j]);
+                        acCounter++;
+                    }
+                    break;
                 case TacticalLines.DELAY:
                 case TacticalLines.WITHDRAW:
                 case TacticalLines.DISENGAGE:
@@ -4690,6 +4785,7 @@ public final class arraysupport {
                 case TacticalLines.TURN:
                 case TacticalLines.MNFLDDIS:
                 case TacticalLines.AREA_DEFENSE:
+                case TacticalLines.MOBILE_DEFENSE:
                     //POINT2 initialFillPt=null;
                     for (k = 0; k < acCounter; k++) {
                         if (k == 0) {

--- a/renderer/src/main/java/armyc2/c5isr/JavaLineArray/arraysupport.java
+++ b/renderer/src/main/java/armyc2/c5isr/JavaLineArray/arraysupport.java
@@ -3793,6 +3793,7 @@ public final class arraysupport {
                     break;
                 case TacticalLines.DELAY:
                 case TacticalLines.WITHDRAW:
+                case TacticalLines.DISENGAGE:
                 case TacticalLines.WDRAWUP:
                 case TacticalLines.RETIRE:
                 case TacticalLines.FPOL:

--- a/renderer/src/main/java/armyc2/c5isr/JavaLineArray/arraysupport.java
+++ b/renderer/src/main/java/armyc2/c5isr/JavaLineArray/arraysupport.java
@@ -305,10 +305,6 @@ public final class arraysupport {
             int j = 0, bolVertical = 0;
             int bolVertical2 = 0;
             int nOrientation = 0; //will use 0 for horiz line from left, 1 for vertical line from top
-            int extendLeft = 0;
-            int extendRight = 1;
-            int extendAbove = 2;
-            int extendBelow = 3;
 
             POINT2 pt2 = new POINT2();
             //end declarations. will use this to determine the direction
@@ -409,36 +405,24 @@ public final class arraysupport {
             switch (nInOutCounter % 2) {
                 case 0:
                     if (nOrientation == 0) {
-                        nDirection = extendLeft;
+                        nDirection = lineutility.extend_left;
                     } else {
-                        nDirection = extendAbove;
+                        nDirection = lineutility.extend_above;
                     }
                     break;
                 case 1:
                     if (nOrientation == 0) {
-                        nDirection = extendRight;
+                        nDirection = lineutility.extend_right;
                     } else {
-                        nDirection = extendBelow;
+                        nDirection = lineutility.extend_below;
                     }
                     break;
                 default:
                     break;
             }
             //reverse direction for ICING
-            switch (lineType) {
-                case TacticalLines.ICING:
-                    if (nDirection == extendLeft) {
-                        nDirection = extendRight;
-                    } else if (nDirection == extendRight) {
-                        nDirection = extendLeft;
-                    } else if (nDirection == extendAbove) {
-                        nDirection = extendBelow;
-                    } else if (nDirection == extendBelow) {
-                        nDirection = extendAbove;
-                    }
-                    break;
-                default:
-                    break;
+            if (lineType == TacticalLines.ICING) {
+                nDirection = lineutility.reverseDirection(nDirection);
             }
         } catch (Exception exc) {
             ErrorLogger.LogException(_className, "GetInsideOutsideDouble2",
@@ -487,22 +471,7 @@ public final class arraysupport {
                 switch (lineType) {
                     case TacticalLines.OBSAREA:
                     case TacticalLines.OBSFAREA:
-                        switch (nDirection) {
-                            case 0:	//extend left
-                                nDirection = 1;	//extend right
-                                break;
-                            case 1:	//extend right
-                                nDirection = 0;	//extend left
-                                break;
-                            case 2:	//extend above
-                                nDirection = 3;	//extend below
-                                break;
-                            case 3:	//extgend below
-                                nDirection = 2;	//extend above
-                                break;
-                            default:
-                                break;
-                        }
+                        nDirection = lineutility.reverseDirection(nDirection);
                         break;
                     default:
                         break;

--- a/renderer/src/main/java/armyc2/c5isr/JavaLineArray/arraysupport.java
+++ b/renderer/src/main/java/armyc2/c5isr/JavaLineArray/arraysupport.java
@@ -3447,160 +3447,6 @@ public final class arraysupport {
                     }
                     acCounter = vblCounter;
                     break;
-                case TacticalLines.INFILTRATION:
-                    // Move pt1 into rectangle between pt1 and pt2
-                    if (pt1.y < pt0.y && pt1.y < pt2.y)
-                        pt1.y = Math.min(pt0.y, pt2.y);
-                    else if (pt1.y > pt0.y && pt1.y > pt2.y)
-                        pt1.y = Math.max(pt0.y, pt2.y);
-                    if (pt1.x < pt0.x && pt1.x < pt2.x)
-                        pt1.x = Math.min(pt0.x, pt2.x);
-                    else if (pt1.x > pt0.x && pt1.x > pt2.x)
-                        pt1.x = Math.max(pt0.x, pt2.x);
-                    dMBR = lineutility.MBRDistance(pLinePoints, vblSaveCounter);
-
-                    lineutility.InitializePOINT2Array(arcPts);
-
-                    if (dMBR / 20 > maxLength * DPIScaleFactor) {
-                        dMBR = 20 * maxLength * DPIScaleFactor;
-                    }
-                    if (dMBR / 20 < minLength * DPIScaleFactor) {
-                        dMBR = 20 * minLength * DPIScaleFactor;
-                    }
-                    if (dMBR < 150 * DPIScaleFactor) {
-                        dMBR = 150 * DPIScaleFactor;
-                    }
-                    if (dMBR > 500 * DPIScaleFactor) {
-                        dMBR = 500 * DPIScaleFactor;
-                    }
-
-                    // Add control points
-                    pLinePoints[0] = pt0;
-                    pLinePoints[18] = pt1;
-                    pLinePoints[36] = pt2;
-
-                    // Add arrow
-                    lineutility.GetArrowHead4Double(new POINT2(pt0.x, pt2.y), pt2, (int) dMBR / 20, (int) dMBR / 20, pArrowPoints, 0);
-                    for (k = 0; k < 3; k++) {
-                        pLinePoints[vblCounter - k - 1] = new POINT2(pArrowPoints[k]);
-                    }
-
-                    // Add curves
-                    if (pt0.y > pt2.y && pt0.x > pt2.x) { // pt0 is bottom right
-                        if (pt1.x < pt0.x) {
-                            dRadius = pt0.y - pt1.y;
-                            DISMSupport.ArcApproximationDouble(pt1.x, pt0.y - 2 * dRadius, Math.min(pt1.x + 2 * dRadius, pt1.x + 2 * (pt0.x - pt1.x)), pt0.y,
-                                    pt1.x, pt1.y, Math.min(pt1.x + dRadius, pt0.x), pt0.y,
-                                    arcPts);
-                            for (k = 0; k < 17; k++) {
-                                pLinePoints[k + 1] = new POINT2(arcPts[16 - k]);
-                            }
-                        } else {
-                            for (k = 0; k < 17; k++) {
-                                pLinePoints[k + 1] = new POINT2(pt1);
-                            }
-                        }
-
-                        if (pt2.x < pt1.x) {
-                            dRadius = pt1.y - pt2.y;
-                            DISMSupport.ArcApproximationDouble(Math.max(pt1.x - 2 * dRadius, pt1.x - 2 * (pt1.x - pt2.x)), pt2.y, pt1.x, pt2.y + dRadius * 2,
-                                    pt1.x, pt1.y, Math.max(pt1.x - dRadius, pt2.x), pt2.y,
-                                    arcPts);
-                            for (k = 0; k < 17; k++) {
-                                pLinePoints[k + 19] = new POINT2(arcPts[k]);
-                            }
-                        } else {
-                            for (k = 0; k < 17; k++) {
-                                pLinePoints[k + 19] = new POINT2(pt1);
-                            }
-                        }
-                    } else if (pt0.y > pt2.y && pt0.x < pt2.x) { // pt0 is bottom left
-                        if (pt0.x < pt1.x) {
-                            dRadius = pt0.y - pt1.y;
-                            DISMSupport.ArcApproximationDouble(Math.max(pt1.x - 2 * dRadius, pt1.x - 2 * (pt1.x - pt0.x)), pt0.y - dRadius * 2, pt1.x, pt0.y,
-                                    Math.max(pt1.x - dRadius, pt0.x), pt0.y, pt1.x, pt1.y,
-                                    arcPts);
-                            for (k = 0; k < 17; k++) {
-                                pLinePoints[k + 1] = new POINT2(arcPts[k]);
-                            }
-                        } else {
-                            for (k = 0; k < 17; k++) {
-                                pLinePoints[k + 1] = new POINT2(pt1);
-                            }
-                        }
-
-                        if (pt1.x < pt2.x) {
-                            dRadius = pt1.y - pt2.y;
-                            DISMSupport.ArcApproximationDouble(pt1.x, pt2.y, Math.min(pt1.x + 2 * dRadius, pt1.x + 2 * (pt2.x - pt1.x)), pt2.y + 2 * dRadius,
-                                    Math.min(pt1.x + dRadius, pt2.x), pt2.y, pt1.x, pt1.y,
-                                    arcPts);
-                            for (k = 0; k < 17; k++) {
-                                pLinePoints[k + 19] = new POINT2(arcPts[16 - k]);
-                            }
-                        } else {
-                            for (k = 0; k < 17; k++) {
-                                pLinePoints[k + 19] = new POINT2(pt1);
-                            }
-                        }
-                    } else if (pt0.y < pt2.y && pt0.x > pt2.x) { // pt0 is top right
-                        if (pt1.x < pt0.x) {
-                            dRadius = pt1.y - pt0.y;
-                            DISMSupport.ArcApproximationDouble(pt1.x, pt0.y, Math.min(pt1.x + 2 * dRadius, pt1.x + 2 * (pt0.x - pt1.x)), pt0.y + 2 * dRadius,
-                                    Math.min(pt1.x + dRadius, pt0.x), pt0.y, pt1.x, pt1.y,
-                                    arcPts);
-                            for (k = 0; k < 17; k++) {
-                                pLinePoints[k + 1] = new POINT2(arcPts[k]);
-                            }
-                        } else {
-                            for (k = 0; k < 17; k++) {
-                                pLinePoints[k + 1] = new POINT2(pt1);
-                            }
-                        }
-
-                        if (pt2.x < pt1.x) {
-                            dRadius = pt2.y - pt1.y;
-                            DISMSupport.ArcApproximationDouble(Math.max(pt1.x - 2 * dRadius, pt1.x - 2 * (pt1.x - pt2.x)), pt2.y - dRadius * 2, pt1.x, pt2.y,
-                                    Math.max(pt1.x - dRadius, pt2.x), pt2.y, pt1.x, pt1.y,
-                                    arcPts);
-                            for (k = 0; k < 17; k++) {
-                                pLinePoints[k + 19] = new POINT2(arcPts[16 - k]);
-                            }
-                        } else {
-                            for (k = 0; k < 17; k++) {
-                                pLinePoints[k + 19] = new POINT2(pt1);
-                            }
-                        }
-                    } else { // if (pt0.y < pt2.y && pt0.x < pt2.x) { // pt0 is top left
-                        if (pt0.x < pt1.x) {
-                            dRadius = pt1.y - pt0.y;
-                            DISMSupport.ArcApproximationDouble(Math.max(pt1.x - 2 * dRadius, pt1.x - 2 * (pt1.x - pt0.x)), pt0.y, pt1.x, pt0.y + dRadius * 2,
-                                    pt1.x, pt1.y, Math.max(pt1.x - dRadius, pt0.x), pt0.y,
-                                    arcPts);
-                            for (k = 0; k < 17; k++) {
-                                pLinePoints[k + 1] = new POINT2(arcPts[16 - k]);
-                            }
-                        } else {
-                            for (k = 0; k < 17; k++) {
-                                pLinePoints[k + 1] = new POINT2(pt1);
-                            }
-                        }
-
-                        if (pt1.x < pt2.x) {
-                            dRadius = pt2.y - pt1.y;
-                            DISMSupport.ArcApproximationDouble(pt1.x, pt2.y - 2 * dRadius, Math.min(pt1.x + 2 * dRadius, pt1.x + 2 * (pt2.x - pt1.x)), pt2.y,
-                                    pt1.x, pt1.y, Math.min(pt1.x + dRadius, pt2.x), pt2.y,
-                                    arcPts);
-                            for (k = 0; k < 17; k++) {
-                                pLinePoints[k + 19] = new POINT2(arcPts[k]);
-                            }
-                        } else {
-                            for (k = 0; k < 17; k++) {
-                                pLinePoints[k + 19] = new POINT2(pt1);
-                            }
-                        }
-                    }
-                    acCounter = vblCounter;
-                    break;
                 case TacticalLines.EXPLOIT:
                     // Convert arrows to 90 degrees with the hypotenuse distance = distance between pt1 and pt2
                     int triBiSector = (int) (lineutility.CalcDistanceDouble(pt1, pt2) / Math.sqrt(2));
@@ -4174,7 +4020,6 @@ public final class arraysupport {
                 case TacticalLines.ABATIS:
                 case TacticalLines.MOBILE_DEFENSE:
                 case TacticalLines.ENVELOPMENT:
-                case TacticalLines.INFILTRATION:
                     FillPoints(pLinePoints, acCounter, points);
                     break;
                 default:
@@ -4880,7 +4725,6 @@ public final class arraysupport {
                     addPolyline(secondPoly, 9, shapes); // Arrow and bowtie
                     break;
                 case TacticalLines.DIRATKSPT:
-                case TacticalLines.INFILTRATION:
                     addPolyline(pLinePoints, acCounter - 3, shapes); // Main line
                     secondPoly = new POINT2[3];
                     for (int i = 0; i < 3; i++) {

--- a/renderer/src/main/java/armyc2/c5isr/JavaLineArray/arraysupport.java
+++ b/renderer/src/main/java/armyc2/c5isr/JavaLineArray/arraysupport.java
@@ -4110,10 +4110,8 @@ public final class arraysupport {
                 case TacticalLines.RETIRE:
                 case TacticalLines.FPOL:
                 case TacticalLines.RPOL:
-                    acCounter = DISMSupport.GetDelayGraphicEtcDouble(pLinePoints);
-                    break;
                 case TacticalLines.PURSUIT:
-                    acCounter = DISMSupport.GetPursuitGraphicDouble(pLinePoints);
+                    acCounter = DISMSupport.GetDelayGraphicEtcDouble(pLinePoints, lineType);
                     break;
                 case TacticalLines.ENVELOPMENT:
                     acCounter = DISMSupport.GetEnvelopmentGraphicDouble(pLinePoints);

--- a/renderer/src/main/java/armyc2/c5isr/JavaLineArray/arraysupport.java
+++ b/renderer/src/main/java/armyc2/c5isr/JavaLineArray/arraysupport.java
@@ -5008,7 +5008,7 @@ public final class arraysupport {
             }
         } catch (Exception exc) {
             ErrorLogger.LogException(_className, "GetLineArray2Double",
-                    new RendererException("GetLineArray2Dboule " + Integer.toString(tg.get_LineType()), exc));
+                    new RendererException("GetLineArray2Double " + Integer.toString(tg.get_LineType()), exc));
         }
         return points;
     }

--- a/renderer/src/main/java/armyc2/c5isr/JavaLineArray/arraysupport.java
+++ b/renderer/src/main/java/armyc2/c5isr/JavaLineArray/arraysupport.java
@@ -3789,6 +3789,7 @@ public final class arraysupport {
                     acCounter = DISMSupport.GetDISMFixDouble(pLinePoints, lineType, clipBounds);
                     break;
                 case TacticalLines.RIP:
+                case TacticalLines.DEMONSTRATE:
                     acCounter = DISMSupport.GetDISMRIPDouble(pLinePoints, lineType);
                     break;
                 case TacticalLines.DELAY:

--- a/renderer/src/main/java/armyc2/c5isr/JavaLineArray/arraysupport.java
+++ b/renderer/src/main/java/armyc2/c5isr/JavaLineArray/arraysupport.java
@@ -3447,6 +3447,23 @@ public final class arraysupport {
                     }
                     acCounter = vblCounter;
                     break;
+                case TacticalLines.EXPLOIT:
+                    // Convert arrows to 90 degrees with the hypotenuse distance = distance between pt1 and pt2
+                    int triBiSector = (int) (lineutility.CalcDistanceDouble(pt1, pt2) / Math.sqrt(2));
+
+                    // Arrow at pt1
+                    lineutility.GetArrowHead4Double(pt1, pt0, triBiSector, triBiSector * 2, pArrowPoints, 0);
+                    for (k = 0; k < 3; k++) {
+                        pLinePoints[k+2] = new POINT2(pArrowPoints[k]);
+                    }
+
+                    // Dashed tail at pt2
+                    lineutility.GetArrowHead4Double(lineutility.ExtendLineDouble(pt0, pt1, 10), pt1, triBiSector, triBiSector * 2, pArrowPoints, 1);
+                    for (k = 0; k < 3; k++) {
+                        pLinePoints[k+5] = new POINT2(pArrowPoints[k]);
+                    }
+                    acCounter = vblCounter;
+                    break;
                 case TacticalLines.ABATIS:
                     //must use an x offset for ptYintercept because of extending from it
                     pts2 = new POINT2[2];
@@ -4716,6 +4733,19 @@ public final class arraysupport {
                         secondPoly[i] = pLinePoints[pLinePoints.length - 3 + i];
                     }
                     addPolyline(secondPoly, 3, shapes); // Arrow
+                    break;
+                case TacticalLines.EXPLOIT:
+                    addPolyline(pLinePoints, 2, shapes); // Main line
+                    secondPoly = new POINT2[3];
+                    for (int i = 0; i < 3; i++) {
+                        secondPoly[i] = pLinePoints[i + 2];
+                    }
+                    addPolyline(secondPoly, 3, shapes); // Arrow at pt1
+                    secondPoly = new POINT2[3];
+                    for (int i = 0; i < 3; i++) {
+                        secondPoly[i] = pLinePoints[i + 5];
+                    }
+                    addPolyline(secondPoly, 3, shapes); // Dashed tail at pt2
                     break;
                 default:
                     addPolyline(pLinePoints, acCounter, shapes);

--- a/renderer/src/main/java/armyc2/c5isr/JavaLineArray/arraysupport.java
+++ b/renderer/src/main/java/armyc2/c5isr/JavaLineArray/arraysupport.java
@@ -3775,6 +3775,7 @@ public final class arraysupport {
                     acCounter = DISMSupport.GetDISMByDifDouble(pLinePoints, lineType, clipBounds);
                     break;
                 case TacticalLines.SEIZE:
+                case TacticalLines.EVACUATE:
                     double radius = 0;
                     if (vblSaveCounter == 4) {
                         radius = lineutility.CalcDistanceDouble(pLinePoints[0], pLinePoints[1]);
@@ -3840,6 +3841,7 @@ public final class arraysupport {
                 case TacticalLines.RETAIN:
                 case TacticalLines.SECURE:
                 case TacticalLines.SEIZE:
+                case TacticalLines.EVACUATE:
                 case TacticalLines.BS_RECTANGLE:
                 case TacticalLines.BBS_RECTANGLE:
                 //add these

--- a/renderer/src/main/java/armyc2/c5isr/JavaLineArray/arraysupport.java
+++ b/renderer/src/main/java/armyc2/c5isr/JavaLineArray/arraysupport.java
@@ -3849,6 +3849,9 @@ public final class arraysupport {
                 case TacticalLines.PURSUIT:
                     acCounter = DISMSupport.GetPursuitGraphicDouble(pLinePoints);
                     break;
+                case TacticalLines.ENVELOPMENT:
+                    acCounter = DISMSupport.GetEnvelopmentGraphicDouble(pLinePoints);
+                    break;
                 case TacticalLines.EASY:
                     acCounter = DISMSupport.GetDISMEasyDouble(pLinePoints, lineType);
                     break;
@@ -3905,6 +3908,8 @@ public final class arraysupport {
                 case TacticalLines.MFLANE:
                 case TacticalLines.DIRATKAIR:
                 case TacticalLines.ABATIS:
+                case TacticalLines.MOBILE_DEFENSE:
+                case TacticalLines.ENVELOPMENT:
                     FillPoints(pLinePoints, acCounter, points);
                     break;
                 default:

--- a/renderer/src/main/java/armyc2/c5isr/JavaLineArray/arraysupport.java
+++ b/renderer/src/main/java/armyc2/c5isr/JavaLineArray/arraysupport.java
@@ -3424,10 +3424,13 @@ public final class arraysupport {
                     acCounter = 14;
                     break;
                 case TacticalLines.DIRATKSPT:
-                    //reverse the points
-                    lineutility.ReversePointsDouble2(
-                            pLinePoints,
-                            vblSaveCounter);
+                case TacticalLines.INFILTRATION:
+                    if (lineType == TacticalLines.DIRATKSPT) {
+                        //reverse the points
+                        lineutility.ReversePointsDouble2(
+                                pLinePoints,
+                                vblSaveCounter);
+                    }
                     if (dMBR / 20 > maxLength * DPIScaleFactor) {
                         dMBR = 20 * maxLength * DPIScaleFactor;
                     }
@@ -4725,6 +4728,7 @@ public final class arraysupport {
                     addPolyline(secondPoly, 9, shapes); // Arrow and bowtie
                     break;
                 case TacticalLines.DIRATKSPT:
+                case TacticalLines.INFILTRATION:
                     addPolyline(pLinePoints, acCounter - 3, shapes); // Main line
                     secondPoly = new POINT2[3];
                     for (int i = 0; i < 3; i++) {

--- a/renderer/src/main/java/armyc2/c5isr/JavaLineArray/countsupport.java
+++ b/renderer/src/main/java/armyc2/c5isr/JavaLineArray/countsupport.java
@@ -371,6 +371,7 @@ public final class countsupport
                     count=2*vblCounter+8;
                     break;
                 case TacticalLines.FRONTAL_ATTACK:
+                case TacticalLines.TURNING_MOVEMENT:
                     count=2*vblCounter+10;
                     break;
                 case TacticalLines.CATKBYFIRE:

--- a/renderer/src/main/java/armyc2/c5isr/JavaLineArray/countsupport.java
+++ b/renderer/src/main/java/armyc2/c5isr/JavaLineArray/countsupport.java
@@ -218,6 +218,7 @@ public final class countsupport
                     count = 22;
                     break;
                 case TacticalLines.WITHDRAW:
+                case TacticalLines.DISENGAGE:
                 case TacticalLines.WDRAWUP:
                 case TacticalLines.DELAY:		//extra four points for hash marks on last segment
                 case TacticalLines.RETIRE:

--- a/renderer/src/main/java/armyc2/c5isr/JavaLineArray/countsupport.java
+++ b/renderer/src/main/java/armyc2/c5isr/JavaLineArray/countsupport.java
@@ -226,6 +226,7 @@ public final class countsupport
                     count = 23;
                     break;
                 case TacticalLines.SEIZE:
+                case TacticalLines.EVACUATE:
                     count = 37;
                     break;
                 case TacticalLines.RIP:

--- a/renderer/src/main/java/armyc2/c5isr/JavaLineArray/countsupport.java
+++ b/renderer/src/main/java/armyc2/c5isr/JavaLineArray/countsupport.java
@@ -245,6 +245,9 @@ public final class countsupport
                 case TacticalLines.DIRATKSPT:
                     count = vblCounter + 3;
                     break;
+                case TacticalLines.INFILTRATION:
+                    count = 40;
+                    break;
                 case TacticalLines.ABATIS:
                     count = vblCounter + 3;
                     break;

--- a/renderer/src/main/java/armyc2/c5isr/JavaLineArray/countsupport.java
+++ b/renderer/src/main/java/armyc2/c5isr/JavaLineArray/countsupport.java
@@ -374,6 +374,9 @@ public final class countsupport
                 case TacticalLines.TURNING_MOVEMENT:
                     count=2*vblCounter+10;
                     break;
+                case TacticalLines.MOVEMENT_TO_CONTACT:
+                    count=2*vblCounter+24;
+                    break;
                 case TacticalLines.CATKBYFIRE:
                     count=2*vblCounter+17;
                     break;

--- a/renderer/src/main/java/armyc2/c5isr/JavaLineArray/countsupport.java
+++ b/renderer/src/main/java/armyc2/c5isr/JavaLineArray/countsupport.java
@@ -231,6 +231,7 @@ public final class countsupport
                     count = 37;
                     break;
                 case TacticalLines.RIP:
+                case TacticalLines.DEMONSTRATE:
                     count = 29;
                     break;
                 case TacticalLines.DIRATKSPT:

--- a/renderer/src/main/java/armyc2/c5isr/JavaLineArray/countsupport.java
+++ b/renderer/src/main/java/armyc2/c5isr/JavaLineArray/countsupport.java
@@ -166,6 +166,7 @@ public final class countsupport
                     break;
                 case TacticalLines.ROADBLK:
                 case TacticalLines.FERRY:
+                case TacticalLines.EXPLOIT:
                     count=8;
                     break;
                 case TacticalLines.NAVIGATION:

--- a/renderer/src/main/java/armyc2/c5isr/JavaLineArray/countsupport.java
+++ b/renderer/src/main/java/armyc2/c5isr/JavaLineArray/countsupport.java
@@ -238,6 +238,9 @@ public final class countsupport
                 case TacticalLines.DEMONSTRATE:
                     count = 29;
                     break;
+                case TacticalLines.MOBILE_DEFENSE:
+                    count = 44;
+                    break;
                 case TacticalLines.DIRATKSPT:
                     count = vblCounter + 3;
                     break;

--- a/renderer/src/main/java/armyc2/c5isr/JavaLineArray/countsupport.java
+++ b/renderer/src/main/java/armyc2/c5isr/JavaLineArray/countsupport.java
@@ -226,6 +226,9 @@ public final class countsupport
                 case TacticalLines.RPOL:
                     count = 23;
                     break;
+                case TacticalLines.PURSUIT:
+                    count = 25;
+                    break;
                 case TacticalLines.SEIZE:
                 case TacticalLines.EVACUATE:
                     count = 37;

--- a/renderer/src/main/java/armyc2/c5isr/JavaLineArray/countsupport.java
+++ b/renderer/src/main/java/armyc2/c5isr/JavaLineArray/countsupport.java
@@ -373,8 +373,10 @@ public final class countsupport
                     count=2*vblCounter+8;
                     break;
                 case TacticalLines.FRONTAL_ATTACK:
+                    count=2*vblCounter+15;
+                    break;
                 case TacticalLines.TURNING_MOVEMENT:
-                    count=2*vblCounter+10;
+                    count=2*vblCounter+14;
                     break;
                 case TacticalLines.MOVEMENT_TO_CONTACT:
                     count=2*vblCounter+24;

--- a/renderer/src/main/java/armyc2/c5isr/JavaLineArray/countsupport.java
+++ b/renderer/src/main/java/armyc2/c5isr/JavaLineArray/countsupport.java
@@ -243,6 +243,7 @@ public final class countsupport
                     count = 44;
                     break;
                 case TacticalLines.DIRATKSPT:
+                case TacticalLines.INFILTRATION:
                     count = vblCounter + 3;
                     break;
                 case TacticalLines.ABATIS:

--- a/renderer/src/main/java/armyc2/c5isr/JavaLineArray/countsupport.java
+++ b/renderer/src/main/java/armyc2/c5isr/JavaLineArray/countsupport.java
@@ -245,9 +245,6 @@ public final class countsupport
                 case TacticalLines.DIRATKSPT:
                     count = vblCounter + 3;
                     break;
-                case TacticalLines.INFILTRATION:
-                    count = 40;
-                    break;
                 case TacticalLines.ABATIS:
                     count = vblCounter + 3;
                     break;

--- a/renderer/src/main/java/armyc2/c5isr/JavaLineArray/countsupport.java
+++ b/renderer/src/main/java/armyc2/c5isr/JavaLineArray/countsupport.java
@@ -370,6 +370,9 @@ public final class countsupport
                     //they have an extra 8 points for the arrowhead
                     count=2*vblCounter+8;
                     break;
+                case TacticalLines.FRONTAL_ATTACK:
+                    count=2*vblCounter+10;
+                    break;
                 case TacticalLines.CATKBYFIRE:
                     count=2*vblCounter+17;
                     break;

--- a/renderer/src/main/java/armyc2/c5isr/JavaLineArray/countsupport.java
+++ b/renderer/src/main/java/armyc2/c5isr/JavaLineArray/countsupport.java
@@ -291,6 +291,9 @@ public final class countsupport
                 case TacticalLines.CORDONSEARCH:
                     count = 50;
                     break;
+                case TacticalLines.AREA_DEFENSE:
+                    count = 67;
+                    break;
                 case TacticalLines.OCCUPY:
                     count = 32;
                     break;

--- a/renderer/src/main/java/armyc2/c5isr/JavaLineArray/countsupport.java
+++ b/renderer/src/main/java/armyc2/c5isr/JavaLineArray/countsupport.java
@@ -224,6 +224,7 @@ public final class countsupport
                 case TacticalLines.RETIRE:
                 case TacticalLines.FPOL:
                 case TacticalLines.RPOL:
+                case TacticalLines.ENVELOPMENT:
                     count = 23;
                     break;
                 case TacticalLines.PURSUIT:

--- a/renderer/src/main/java/armyc2/c5isr/JavaLineArray/lineutility.java
+++ b/renderer/src/main/java/armyc2/c5isr/JavaLineArray/lineutility.java
@@ -3547,6 +3547,31 @@ public final class lineutility {
     }  // end
 
     /**
+     * Returns the point on line (pt0 to pt1) closest to ptRelative
+     *
+     * @param pt0 the first point on line
+     * @param pt1 the second point on line
+     * @param ptRelative the second point on line
+     * @return the point closest to ptRelative on the line
+     */
+    public static POINT2 ClosestPointOnLine(POINT2 pt0, POINT2 pt1, POINT2 ptRelative) {
+        if (pt0.x == ptRelative.x && pt0.y == ptRelative.y)
+            return new POINT2(pt0);
+        else if (pt1.x == ptRelative.x && pt1.y == ptRelative.y)
+            return new POINT2(pt1);
+        else if (pt0.x == pt1.x && pt0.y == pt1.y)
+            return new POINT2(pt0);
+
+        POINT2 atob = new POINT2(pt1.x - pt0.x,  pt1.y - pt0.y );
+        POINT2 atop = new POINT2(ptRelative.x - pt0.x,  ptRelative.y - pt0.y );
+        double len = atob.x * atob.x + atob.y * atob.y;
+        double dot = atop.x * atob.x + atop.y * atob.y;
+        double t = Math.min( 1, Math.max( 0, dot / len ) );
+
+        return new POINT2(pt0.x + atob.x * t, pt0.y + atob.y * t);
+    }
+
+    /**
      * Returns the point perpendicular to the line (pt0 to pt1) at the midpoint
      * the same distance from (and on the same side of) the the line as
      * ptRelative.

--- a/renderer/src/main/java/armyc2/c5isr/JavaLineArray/lineutility.java
+++ b/renderer/src/main/java/armyc2/c5isr/JavaLineArray/lineutility.java
@@ -1154,22 +1154,7 @@ public final class lineutility {
             ref<double[]> X = new ref(), Y = new ref();
             ptResult = new POINT2(pt0);
             if (d < 0) {
-                switch (direction) {
-                    case 0:
-                        direction = extend_right;
-                        break;
-                    case 1:
-                        direction = extend_left;
-                        break;
-                    case 2:
-                        direction = extend_below;
-                        break;
-                    case 3:
-                        direction = extend_above;
-                        break;
-                    default:
-                        break;
-                }
+                direction = reverseDirection(direction);
                 d = Math.abs(d);
             }
             if (pt1.y == pt2.y)//horizontal segment
@@ -4161,22 +4146,7 @@ public final class lineutility {
             direction = arraysupport.GetInsideOutsideDouble2(pt0, pt1, pts, vblCounter, index, lineType);
             //reverse the direction if these are interior points
             if (interior == true) {
-                switch (direction) {
-                    case 0:
-                        direction = 1;
-                        break;
-                    case 1:
-                        direction = 0;
-                        break;
-                    case 2:
-                        direction = 3;
-                        break;
-                    case 3:
-                        direction = 2;
-                        break;
-                    default:
-                        break;
-                }
+                direction = reverseDirection(direction);
             }
             //pt00-pt01 will be the interior line inside line pt0-pt1
             //pt00 is inside pt0, pt01 is inside pt1
@@ -4192,22 +4162,7 @@ public final class lineutility {
             direction = arraysupport.GetInsideOutsideDouble2(pt1, pt2, (POINT2[]) pts, vblCounter, index, lineType);
             //reverse the direction if these are interior points
             if (interior == true) {
-                switch (direction) {
-                    case 0:
-                        direction = 1;
-                        break;
-                    case 1:
-                        direction = 0;
-                        break;
-                    case 2:
-                        direction = 3;
-                        break;
-                    case 3:
-                        direction = 2;
-                        break;
-                    default:
-                        break;
-                }
+                direction =reverseDirection(direction);
             }
             pt10 = lineutility.ExtendDirectedLine(pt1, pt2, pt1, direction, dist);
             pt11 = lineutility.ExtendDirectedLine(pt1, pt2, pt2, direction, dist);

--- a/renderer/src/main/java/armyc2/c5isr/JavaLineArray/lineutility.java
+++ b/renderer/src/main/java/armyc2/c5isr/JavaLineArray/lineutility.java
@@ -1026,13 +1026,12 @@ public final class lineutility {
      *
      * @param pt0 first point fo the line
      * @param pt1 last point of the line
-     * @param pt2 relative point
-     * @deprecated
+     * @param ptRelative relative point
      * @return 0 if left, 1 if right, 2 if above, 3 if below
      */
     protected static int CalcDirectionFromLine(POINT2 pt0,
             POINT2 pt1,
-            POINT2 pt2) {
+            POINT2 ptRelative) {
         int result = -1;
         try {
             double m2 = 0, b1 = 0, b2 = 0;
@@ -1041,7 +1040,7 @@ public final class lineutility {
             //int direction=-1;
             //handle vertical line
             if (pt0.x == pt1.x) {
-                if (pt2.x < pt0.x) {
+                if (ptRelative.x < pt0.x) {
                     return 0;
                 } else {
                     return 1;
@@ -1049,32 +1048,32 @@ public final class lineutility {
             }
             //handle horizontal line so that we do not have slope = 0.
             if (pt0.y == pt1.y) {
-                if (pt2.y < pt0.y) {
+                if (ptRelative.y < pt0.y) {
                     return 2;
                 } else {
                     return 3;
                 }
             }
             CalcTrueSlopeDouble(pt0, pt1, m1);
-            m2 = -1 / m1.value[0];	//slope for the perpendicular line from the line to pt2
+            m2 = -1 / m1.value[0];	//slope for the perpendicular line from the line to ptRelative
             //b=mx-y line equation for line
             b1 = pt0.y - m1.value[0] * pt0.x;
-            //b=mx-y line equation for perpendicular line which contains pt2
-            b2 = pt2.y - m2 * pt2.x;
+            //b=mx-y line equation for perpendicular line which contains ptRelative
+            b2 = ptRelative.y - m2 * ptRelative.x;
             ptIntersect = CalcTrueIntersectDouble2(m1.value[0], b1, m2, b2, 1, 1, 0, 0);
-            //compare the intersection point with pt2 to get the direction,
+            //compare the intersection point with ptRelative to get the direction,
             //i.e. the direction from the line is the same as the direction
             //from the interseciton point.
             if (m1.value[0] > 1) //line is steep, use left/right
             {
-                if (pt2.x < ptIntersect.x) {
+                if (ptRelative.x < ptIntersect.x) {
                     return 0;
                 } else {
                     return 1;
                 }
             } else //line is not steep, use above/below
             {
-                if (pt2.y < ptIntersect.y) {
+                if (ptRelative.y < ptIntersect.y) {
                     return 2;
                 } else {
                     return 3;
@@ -4269,4 +4268,18 @@ public final class lineutility {
         return deepCopy;
     }
 
+    public static int reverseDirection(int direction) {
+        switch (direction) {
+            case extend_left:
+                return extend_right;
+            case extend_right:
+                return extend_left;
+            case extend_above:
+                return extend_below;
+            case extend_below:
+                return extend_above;
+            default:
+                return direction;
+        }
+    }
 }//end lineutility

--- a/renderer/src/main/java/armyc2/c5isr/JavaLineArray/lineutility.java
+++ b/renderer/src/main/java/armyc2/c5isr/JavaLineArray/lineutility.java
@@ -2354,6 +2354,7 @@ public final class lineutility {
                 case TacticalLines.ISOLATE:
                 case TacticalLines.CORDONKNOCK:
                 case TacticalLines.CORDONSEARCH:
+                case TacticalLines.AREA_DEFENSE:
                     startangle = M;
                     endangle = startangle + 330 * Math.PI / 180;
                     break;
@@ -2381,6 +2382,7 @@ public final class lineutility {
                     case TacticalLines.ISOLATE:
                     case TacticalLines.CORDONKNOCK:
                     case TacticalLines.CORDONSEARCH:
+                    case TacticalLines.AREA_DEFENSE:
                         startangle = M - Math.PI;
                         endangle = startangle + 330 * Math.PI / 180;
                         break;

--- a/renderer/src/main/java/armyc2/c5isr/JavaTacticalRenderer/Modifier2.java
+++ b/renderer/src/main/java/armyc2/c5isr/JavaTacticalRenderer/Modifier2.java
@@ -460,7 +460,10 @@ public class Modifier2 {
                 case TacticalLines.ATI:
                 case TacticalLines.ATI_CIRCULAR:
                 case TacticalLines.ATI_RECTANGULAR:
-                    label = "ATI ZONE";
+                    if (SymbolID.getVersion(tg.get_SymbolId()) >= SymbolID.Version_2525Ech1)
+                        label = "ATIZ";
+                    else
+                        label = "ATI ZONE";
                     break;
                 case TacticalLines.PAA:
                 case TacticalLines.PAA_CIRCULAR:

--- a/renderer/src/main/java/armyc2/c5isr/JavaTacticalRenderer/Modifier2.java
+++ b/renderer/src/main/java/armyc2/c5isr/JavaTacticalRenderer/Modifier2.java
@@ -270,6 +270,9 @@ public class Modifier2 {
                 case TacticalLines.RIP:
                     label = "RIP";
                     break;
+                case TacticalLines.MOBILE_DEFENSE:
+                    label = "MD";
+                    break;
                 case TacticalLines.DEMONSTRATE:
                     label = "DEM";
                     break;
@@ -3578,6 +3581,7 @@ public class Modifier2 {
                 case TacticalLines.SHIP_AOI_CIRCULAR:
                 case TacticalLines.MFLANE:
                 case TacticalLines.ENVELOPMENT:
+                case TacticalLines.MOBILE_DEFENSE:
                     break;
                 default:
                     return;
@@ -3996,6 +4000,9 @@ public class Modifier2 {
                     break;
                 case TacticalLines.ENVELOPMENT:
                     AddIntegralModifier(tg, label, aboveMiddle, 0, 0, 1, true);
+                    break;
+                case TacticalLines.MOBILE_DEFENSE:
+                    AddIntegralModifier(tg, label, area, 0, 16, 16, true);
                     break;
                 default:
                     break;

--- a/renderer/src/main/java/armyc2/c5isr/JavaTacticalRenderer/Modifier2.java
+++ b/renderer/src/main/java/armyc2/c5isr/JavaTacticalRenderer/Modifier2.java
@@ -599,6 +599,9 @@ public class Modifier2 {
                 case TacticalLines.FRONTAL_ATTACK:
                     label = "A";
                     break;
+                case TacticalLines.TURNING_MOVEMENT:
+                    label = "T";
+                    break;
                 default:
                     break;
             }
@@ -2162,6 +2165,7 @@ public class Modifier2 {
                 case TacticalLines.ANCHORAGE_AREA:
                 case TacticalLines.SPT:
                 case TacticalLines.FRONTAL_ATTACK:
+                case TacticalLines.TURNING_MOVEMENT:
                 case TacticalLines.AIRAOA:
                 case TacticalLines.AAAAA:
                 case TacticalLines.MAIN:
@@ -2465,6 +2469,7 @@ public class Modifier2 {
                     break;
                 case TacticalLines.SPT:
                 case TacticalLines.FRONTAL_ATTACK:
+                case TacticalLines.TURNING_MOVEMENT:
                 case TacticalLines.AIRAOA:
                 case TacticalLines.AAAAA:
                 case TacticalLines.MAIN:
@@ -2489,7 +2494,7 @@ public class Modifier2 {
                         midPt = lineutility.MidPointDouble(pt2, pt3, 0);
                         AddIntegralAreaModifier(tg, tg.get_Name(), aboveMiddle, -csFactor / 2, midPt, midPt, false);
                     }
-                    if (linetype == TacticalLines.FRONTAL_ATTACK) {
+                    if (linetype == TacticalLines.FRONTAL_ATTACK || linetype == TacticalLines.TURNING_MOVEMENT) {
                         midPt=lineutility.ClosestPointOnLine(pt0, pt1, ptLast);
                         AddIntegralAreaModifier(tg, label, aboveMiddle, 0.5 * csFactor, midPt, pt0, true);
                     }

--- a/renderer/src/main/java/armyc2/c5isr/JavaTacticalRenderer/Modifier2.java
+++ b/renderer/src/main/java/armyc2/c5isr/JavaTacticalRenderer/Modifier2.java
@@ -181,6 +181,9 @@ public class Modifier2 {
                 case TacticalLines.SEIZE:
                     label = "S";
                     break;
+                case TacticalLines.EVACUATE:
+                    label = "E";
+                    break;
                 case TacticalLines.RETAIN:
                     label = "R";
                     break;
@@ -3491,6 +3494,7 @@ public class Modifier2 {
                 case TacticalLines.SECURE:
                 case TacticalLines.CONTAIN:
                 case TacticalLines.SEIZE:
+                case TacticalLines.EVACUATE:
                 case TacticalLines.CORDONKNOCK:
                 case TacticalLines.CORDONSEARCH:
                 case TacticalLines.FOLLA:
@@ -3675,6 +3679,7 @@ public class Modifier2 {
                     }
                     break;
                 case TacticalLines.SEIZE:
+                case TacticalLines.EVACUATE:
                     pt0 = tg.Pixels.get(26);
                     pt1 = tg.Pixels.get(27);
                     //pt1=lineutility.ExtendAlongLineDouble(pt1, pt0, -10);

--- a/renderer/src/main/java/armyc2/c5isr/JavaTacticalRenderer/Modifier2.java
+++ b/renderer/src/main/java/armyc2/c5isr/JavaTacticalRenderer/Modifier2.java
@@ -596,6 +596,9 @@ public class Modifier2 {
                 case TacticalLines.TRIP:
                     label = "t";
                     break;
+                case TacticalLines.FRONTAL_ATTACK:
+                    label = "A";
+                    break;
                 default:
                     break;
             }
@@ -2158,6 +2161,7 @@ public class Modifier2 {
                 case TacticalLines.ANCHORAGE_LINE:
                 case TacticalLines.ANCHORAGE_AREA:
                 case TacticalLines.SPT:
+                case TacticalLines.FRONTAL_ATTACK:
                 case TacticalLines.AIRAOA:
                 case TacticalLines.AAAAA:
                 case TacticalLines.MAIN:
@@ -2460,6 +2464,7 @@ public class Modifier2 {
                     addDTG(tg, aboveMiddle, csFactor, 2 * csFactor, pt0, pt1, metrics);
                     break;
                 case TacticalLines.SPT:
+                case TacticalLines.FRONTAL_ATTACK:
                 case TacticalLines.AIRAOA:
                 case TacticalLines.AAAAA:
                 case TacticalLines.MAIN:
@@ -2483,6 +2488,10 @@ public class Modifier2 {
                         AddIntegralAreaModifier(tg, tg.get_DTG1(), aboveMiddle, csFactor / 2, midPt, midPt, false);
                         midPt = lineutility.MidPointDouble(pt2, pt3, 0);
                         AddIntegralAreaModifier(tg, tg.get_Name(), aboveMiddle, -csFactor / 2, midPt, midPt, false);
+                    }
+                    if (linetype == TacticalLines.FRONTAL_ATTACK) {
+                        midPt=lineutility.ClosestPointOnLine(pt0, pt1, ptLast);
+                        AddIntegralAreaModifier(tg, label, aboveMiddle, 0.5 * csFactor, midPt, pt0, true);
                     }
                     break;
                 case TacticalLines.LL:

--- a/renderer/src/main/java/armyc2/c5isr/JavaTacticalRenderer/Modifier2.java
+++ b/renderer/src/main/java/armyc2/c5isr/JavaTacticalRenderer/Modifier2.java
@@ -4369,21 +4369,6 @@ public class Modifier2 {
         }
     }
 
-    private static int switchDirection(int direction) {
-        int result = -1;
-        switch (direction) {
-            case 0:
-                return 1;
-            case 1:
-                return 0;
-            case 2:
-                return 3;
-            case 3:
-                return 2;
-        }
-        return result;
-    }
-
     /**
      * Displays the modifiers to a Graphics2D from a BufferedImage
      *
@@ -4488,7 +4473,7 @@ public class Modifier2 {
                         }
 
                         if (lineType == TacticalLines.LC || tg.get_Client().equalsIgnoreCase("ge")) {
-                            direction = switchDirection(direction);
+                            direction = lineutility.reverseDirection(direction);
                         }
 
                         if ((modifier.type == toEnd && x1 < x2) || (modifier.type == aboveEnd && x2 < x1)) {

--- a/renderer/src/main/java/armyc2/c5isr/JavaTacticalRenderer/Modifier2.java
+++ b/renderer/src/main/java/armyc2/c5isr/JavaTacticalRenderer/Modifier2.java
@@ -264,6 +264,9 @@ public class Modifier2 {
                 case TacticalLines.WITHDRAW:
                     label = "W";
                     break;
+                case TacticalLines.DISENGAGE:
+                    label = "DIS";
+                    break;
                 case TacticalLines.WDRAWUP:
                     label = "WP";
                     break;
@@ -2104,6 +2107,7 @@ public class Modifier2 {
                 case TacticalLines.FPOL:
                 case TacticalLines.RPOL:
                 case TacticalLines.WITHDRAW:
+                case TacticalLines.DISENGAGE:
                 case TacticalLines.WDRAWUP:
                 case TacticalLines.BEARING:
                 case TacticalLines.BEARING_J:
@@ -3147,6 +3151,7 @@ public class Modifier2 {
                     break;
                 case TacticalLines.RETIRE:
                 case TacticalLines.WITHDRAW:
+                case TacticalLines.DISENGAGE:
                 case TacticalLines.WDRAWUP:
                 case TacticalLines.FPOL:
                 case TacticalLines.RPOL:

--- a/renderer/src/main/java/armyc2/c5isr/JavaTacticalRenderer/Modifier2.java
+++ b/renderer/src/main/java/armyc2/c5isr/JavaTacticalRenderer/Modifier2.java
@@ -596,9 +596,6 @@ public class Modifier2 {
                 case TacticalLines.TRIP:
                     label = "t";
                     break;
-                case TacticalLines.INFILTRATION:
-                    label = "IN";
-                    break;
                 case TacticalLines.FRONTAL_ATTACK:
                     label = "A";
                     break;
@@ -3601,7 +3598,6 @@ public class Modifier2 {
                 case TacticalLines.MFLANE:
                 case TacticalLines.ENVELOPMENT:
                 case TacticalLines.MOBILE_DEFENSE:
-                case TacticalLines.INFILTRATION:
                     break;
                 default:
                     return;
@@ -4023,9 +4019,6 @@ public class Modifier2 {
                     break;
                 case TacticalLines.MOBILE_DEFENSE:
                     AddIntegralModifier(tg, label, area, 0, 16, 16, true);
-                    break;
-                case TacticalLines.INFILTRATION:
-                    AddIntegralModifier(tg, label, aboveMiddle, 0, 0, 1, true);
                     break;
                 default:
                     break;

--- a/renderer/src/main/java/armyc2/c5isr/JavaTacticalRenderer/Modifier2.java
+++ b/renderer/src/main/java/armyc2/c5isr/JavaTacticalRenderer/Modifier2.java
@@ -343,6 +343,7 @@ public class Modifier2 {
                 case TacticalLines.HIMEZ:
                     label = "HIMEZ";
                     break;
+                case TacticalLines.WFZ_REVD:
                 case TacticalLines.WFZ:
                     label = "WFZ";
                     break;
@@ -2055,6 +2056,7 @@ public class Modifier2 {
                 case TacticalLines.GENERIC_AREA:
                 case TacticalLines.ATKPOS:
                 case TacticalLines.ASSAULT:
+                case TacticalLines.WFZ_REVD:
                 case TacticalLines.WFZ:
                 case TacticalLines.OBSFAREA:
                 case TacticalLines.OBSAREA:
@@ -3076,11 +3078,19 @@ public class Modifier2 {
                     addModifierBottomSegment(tg, tg.get_EchelonSymbol());
                     addNModifier(tg);
                     break;
-                case TacticalLines.WFZ:
+                case TacticalLines.WFZ_REVD:
                     AddIntegralAreaModifier(tg, label, area, -1.5 * csFactor, ptCenter, ptCenter, true);
                     AddIntegralAreaModifier(tg, tg.get_Name(), area, -0.5 * csFactor, ptCenter, ptCenter, true);
                     AddIntegralAreaModifier(tg, "TIME FROM: " + tg.get_DTG(), area, 0.5 * csFactor, ptCenter, ptCenter, true, "W");
                     AddIntegralAreaModifier(tg, "TIME TO: " + tg.get_DTG1(), area, 1.5 * csFactor, ptCenter, ptCenter, true, "W1");
+                    break;
+                case TacticalLines.WFZ:
+                    AddIntegralAreaModifier(tg, label, area, -2.5 * csFactor, ptCenter, ptCenter, true);
+                    AddIntegralAreaModifier(tg, tg.get_Name(), area, -1.5 * csFactor, ptCenter, ptCenter, true);
+                    AddIntegralAreaModifier(tg, "TIME FROM: " + tg.get_DTG(), area, -0.5 * csFactor, ptCenter, ptCenter, true, "W");
+                    AddIntegralAreaModifier(tg, "TIME TO: " + tg.get_DTG1(), area, 0.5 * csFactor, ptCenter, ptCenter, true, "W1");
+                    AddIntegralAreaModifier(tg, "MIN ALT: " + tg.get_X(), area, 1.5 * csFactor, ptCenter, ptCenter, false, "H");
+                    AddIntegralAreaModifier(tg, "MAX ALT: " + tg.get_X1(), area, 2.5, ptCenter, ptCenter, false, "H1");
                     break;
                 case TacticalLines.OBSFAREA:
                     AddIntegralAreaModifier(tg, label, area, -1.5 * csFactor, ptCenter, ptCenter, false);

--- a/renderer/src/main/java/armyc2/c5isr/JavaTacticalRenderer/Modifier2.java
+++ b/renderer/src/main/java/armyc2/c5isr/JavaTacticalRenderer/Modifier2.java
@@ -596,12 +596,6 @@ public class Modifier2 {
                 case TacticalLines.TRIP:
                     label = "t";
                     break;
-                case TacticalLines.FRONTAL_ATTACK:
-                    label = "A";
-                    break;
-                case TacticalLines.TURNING_MOVEMENT:
-                    label = "T";
-                    break;
                 case TacticalLines.INFILTRATION:
                     label = "IN";
                     break;
@@ -2503,11 +2497,6 @@ public class Modifier2 {
                         midPt = lineutility.MidPointDouble(pt2, pt3, 0);
                         AddIntegralAreaModifier(tg, tg.get_Name(), aboveMiddle, -csFactor / 2, midPt, midPt, false);
                     }
-                    if (linetype == TacticalLines.FRONTAL_ATTACK || linetype == TacticalLines.TURNING_MOVEMENT) {
-                        midPt=lineutility.ClosestPointOnLine(pt0, pt1, ptLast);
-                        AddIntegralAreaModifier(tg, label, aboveMiddle, 0.5 * csFactor, midPt, pt0, true);
-                    }
-                    break;
                 case TacticalLines.LL:
                 case TacticalLines.LOD:
                 case TacticalLines.LDLC:

--- a/renderer/src/main/java/armyc2/c5isr/JavaTacticalRenderer/Modifier2.java
+++ b/renderer/src/main/java/armyc2/c5isr/JavaTacticalRenderer/Modifier2.java
@@ -2166,6 +2166,7 @@ public class Modifier2 {
                 case TacticalLines.SPT:
                 case TacticalLines.FRONTAL_ATTACK:
                 case TacticalLines.TURNING_MOVEMENT:
+                case TacticalLines.MOVEMENT_TO_CONTACT:
                 case TacticalLines.AIRAOA:
                 case TacticalLines.AAAAA:
                 case TacticalLines.MAIN:
@@ -2470,6 +2471,7 @@ public class Modifier2 {
                 case TacticalLines.SPT:
                 case TacticalLines.FRONTAL_ATTACK:
                 case TacticalLines.TURNING_MOVEMENT:
+                case TacticalLines.MOVEMENT_TO_CONTACT:
                 case TacticalLines.AIRAOA:
                 case TacticalLines.AAAAA:
                 case TacticalLines.MAIN:

--- a/renderer/src/main/java/armyc2/c5isr/JavaTacticalRenderer/Modifier2.java
+++ b/renderer/src/main/java/armyc2/c5isr/JavaTacticalRenderer/Modifier2.java
@@ -222,6 +222,9 @@ public class Modifier2 {
                 case TacticalLines.RETIRE:
                     label = "R";
                     break;
+                case TacticalLines.PURSUIT:
+                    label = "P";
+                    break;
                 case TacticalLines.FPOL:
                     label = "P(F)";
                     break;
@@ -2111,6 +2114,7 @@ public class Modifier2 {
                 case TacticalLines.IL:
                 case TacticalLines.DRCL:
                 case TacticalLines.RETIRE:
+                case TacticalLines.PURSUIT:
                 case TacticalLines.FPOL:
                 case TacticalLines.RPOL:
                 case TacticalLines.WITHDRAW:
@@ -3160,6 +3164,7 @@ public class Modifier2 {
                     AddIntegralModifier(tg, tg.get_Name(), aboveMiddle, 0, 1, 0, false);
                     break;
                 case TacticalLines.RETIRE:
+                case TacticalLines.PURSUIT:
                 case TacticalLines.WITHDRAW:
                 case TacticalLines.DISENGAGE:
                 case TacticalLines.WDRAWUP:

--- a/renderer/src/main/java/armyc2/c5isr/JavaTacticalRenderer/Modifier2.java
+++ b/renderer/src/main/java/armyc2/c5isr/JavaTacticalRenderer/Modifier2.java
@@ -554,6 +554,9 @@ public class Modifier2 {
                 case TacticalLines.DHA:
                     label = "DHA";
                     break;
+                case TacticalLines.KILL_ZONE:
+                    label = "KILL ZONE";
+                    break;
                 case TacticalLines.FARP:
                     label = "FARP";
                     break;
@@ -1980,6 +1983,7 @@ public class Modifier2 {
                 case TacticalLines.ROUTE_ALT:
                 case TacticalLines.DHA_REVD:
                 case TacticalLines.DHA:
+                case TacticalLines.KILL_ZONE:
                 case TacticalLines.EPW:
                 case TacticalLines.UXO:
                 case TacticalLines.FARP:
@@ -2835,6 +2839,7 @@ public class Modifier2 {
                     addNModifier(tg);
                     break;
                 case TacticalLines.DHA:
+                case TacticalLines.KILL_ZONE:
                 case TacticalLines.FARP:
                     AddIntegralAreaModifier(tg, label, area, -0.5 * csFactor, ptCenter, ptCenter, false);
                     AddIntegralAreaModifier(tg, tg.get_Name(), area, 0.5 * csFactor, ptCenter, ptCenter, false);

--- a/renderer/src/main/java/armyc2/c5isr/JavaTacticalRenderer/Modifier2.java
+++ b/renderer/src/main/java/armyc2/c5isr/JavaTacticalRenderer/Modifier2.java
@@ -228,6 +228,9 @@ public class Modifier2 {
                 case TacticalLines.PURSUIT:
                     label = "P";
                     break;
+                case TacticalLines.ENVELOPMENT:
+                    label = "E";
+                    break;
                 case TacticalLines.FPOL:
                     label = "P(F)";
                     break;
@@ -3574,6 +3577,7 @@ public class Modifier2 {
                 case TacticalLines.RADAR_SEARCH:
                 case TacticalLines.SHIP_AOI_CIRCULAR:
                 case TacticalLines.MFLANE:
+                case TacticalLines.ENVELOPMENT:
                     break;
                 default:
                     return;
@@ -3989,6 +3993,9 @@ public class Modifier2 {
                 case TacticalLines.RANGE_FAN_SECTOR:
                 case TacticalLines.RADAR_SEARCH:
                     addSectorModifiers(tg, converter);
+                    break;
+                case TacticalLines.ENVELOPMENT:
+                    AddIntegralModifier(tg, label, aboveMiddle, 0, 0, 1, true);
                     break;
                 default:
                     break;

--- a/renderer/src/main/java/armyc2/c5isr/JavaTacticalRenderer/Modifier2.java
+++ b/renderer/src/main/java/armyc2/c5isr/JavaTacticalRenderer/Modifier2.java
@@ -196,6 +196,9 @@ public class Modifier2 {
                 case TacticalLines.ISOLATE:
                     label = "I";
                     break;
+                case TacticalLines.AREA_DEFENSE:
+                    label = "AD";
+                    break;
                 case TacticalLines.FIX:
                     label = "F";
                     break;
@@ -3513,6 +3516,7 @@ public class Modifier2 {
                 case TacticalLines.OCCUPY:
                 case TacticalLines.RETAIN:
                 case TacticalLines.SECURE:
+                case TacticalLines.AREA_DEFENSE:
                 case TacticalLines.CONTAIN:
                 case TacticalLines.SEIZE:
                 case TacticalLines.EVACUATE:
@@ -3678,6 +3682,7 @@ public class Modifier2 {
                 case TacticalLines.OCCUPY:
                 case TacticalLines.RETAIN:
                 case TacticalLines.SECURE:
+                case TacticalLines.AREA_DEFENSE:
                     pt0 = tg.Pixels.get(13);
                     pt1 = tg.Pixels.get(14);
                     //pt1=lineutility.ExtendAlongLineDouble(pt1, pt0, -10);

--- a/renderer/src/main/java/armyc2/c5isr/JavaTacticalRenderer/Modifier2.java
+++ b/renderer/src/main/java/armyc2/c5isr/JavaTacticalRenderer/Modifier2.java
@@ -2598,8 +2598,9 @@ public class Modifier2 {
                     AddIntegralAreaModifier(tg, tg.get_T1(), area, -2 * csFactor, ptCenter, ptCenter, false);
                     AddIntegralAreaModifier(tg, "MIN ALT: " + tg.get_X(), area, -1 * csFactor, ptCenter, ptCenter, false, "H");
                     AddIntegralAreaModifier(tg, "MAX ALT: " + tg.get_X1(), area, 0, ptCenter, ptCenter, false, "H1");
-                    AddIntegralAreaModifier(tg, tg.get_Location(), area, 1 * csFactor, ptCenter, ptCenter, false, "H2");
-                    addDTG(tg, area, 2 * csFactor, 3 * csFactor, ptCenter, ptCenter, metrics);
+                    AddIntegralAreaModifier(tg, "GRID " + tg.get_Location(), area, 1 * csFactor, ptCenter, ptCenter, false, "H2");
+                    AddModifier2(tg, "EFF " + tg.get_DTG() + WDash, area, 2 * csFactor, ptCenter, ptCenter, false, "W");
+                    AddModifier2(tg, tg.get_DTG1(), area, 3 * csFactor, ptCenter, ptCenter, false, "W1");
                     break;
                 case TacticalLines.MFP:
                     pt0 = tg.Pixels.get(middleSegment);
@@ -3771,8 +3772,8 @@ public class Modifier2 {
                     AddModifier2(tg, tg.get_T1(), aboveMiddle, -2 * csFactor, ptLeft, ptRight, false, "T1");
                     AddModifier2(tg, "MIN ALT: " + tg.get_X(), aboveMiddle, -1 * csFactor, ptLeft, ptRight, false, "H");
                     AddModifier2(tg, "MAX ALT: " + tg.get_X1(), aboveMiddle, 0, ptLeft, ptRight, false, "H1");
-                    AddModifier2(tg, "Grids: " + tg.get_H(), aboveMiddle, 1 * csFactor, ptLeft, ptRight, false, "H2");
-                    AddModifier2(tg, "EFF: " + tg.get_DTG() + WDash, aboveMiddle, 2 * csFactor, ptLeft, ptRight, false, "W");
+                    AddModifier2(tg, "GRID " + tg.get_Location(), aboveMiddle, 1 * csFactor, ptLeft, ptRight, false, "H2");
+                    AddModifier2(tg, "EFF " + tg.get_DTG() + WDash, aboveMiddle, 2 * csFactor, ptLeft, ptRight, false, "W");
                     AddModifier2(tg, tg.get_DTG1(), aboveMiddle, 3 * csFactor, ptLeft, ptRight, false, "W1");
                     break;
                 case TacticalLines.ACA_CIRCULAR:
@@ -3781,8 +3782,8 @@ public class Modifier2 {
                     AddModifier2(tg, tg.get_T1(), area, -2 * csFactor, ptCenter, ptCenter, false, "T1");
                     AddIntegralAreaModifier(tg, "MIN ALT: " + tg.get_X(), area, -1 * csFactor, ptCenter, ptCenter, false, "H");
                     AddIntegralAreaModifier(tg, "MAX ALT: " + tg.get_X1(), area, 0, ptCenter, ptCenter, false, "H1");
-                    AddIntegralAreaModifier(tg, "Grids: " + tg.get_H(), area, 1 * csFactor, ptCenter, ptCenter, false, "H2");
-                    AddIntegralAreaModifier(tg, "EFF: " + tg.get_DTG() + WDash, area, 2 * csFactor, ptCenter, ptCenter, false, "W");
+                    AddIntegralAreaModifier(tg, "GRID " + tg.get_Location(), area, 1 * csFactor, ptCenter, ptCenter, false, "H2");
+                    AddIntegralAreaModifier(tg, "EFF " + tg.get_DTG() + WDash, area, 2 * csFactor, ptCenter, ptCenter, false, "W");
                     AddIntegralAreaModifier(tg, tg.get_DTG1(), area, 3 * csFactor, ptCenter, ptCenter, false, "W1");
                     break;
                 case TacticalLines.FSA_CIRCULAR:

--- a/renderer/src/main/java/armyc2/c5isr/JavaTacticalRenderer/Modifier2.java
+++ b/renderer/src/main/java/armyc2/c5isr/JavaTacticalRenderer/Modifier2.java
@@ -596,6 +596,9 @@ public class Modifier2 {
                 case TacticalLines.TRIP:
                     label = "t";
                     break;
+                case TacticalLines.INFILTRATION:
+                    label = "IN";
+                    break;
                 case TacticalLines.FRONTAL_ATTACK:
                     label = "A";
                     break;
@@ -3598,6 +3601,7 @@ public class Modifier2 {
                 case TacticalLines.MFLANE:
                 case TacticalLines.ENVELOPMENT:
                 case TacticalLines.MOBILE_DEFENSE:
+                case TacticalLines.INFILTRATION:
                     break;
                 default:
                     return;
@@ -4019,6 +4023,9 @@ public class Modifier2 {
                     break;
                 case TacticalLines.MOBILE_DEFENSE:
                     AddIntegralModifier(tg, label, area, 0, 16, 16, true);
+                    break;
+                case TacticalLines.INFILTRATION:
+                    AddIntegralModifier(tg, label, aboveMiddle, 0, 0, 1, true);
                     break;
                 default:
                     break;

--- a/renderer/src/main/java/armyc2/c5isr/JavaTacticalRenderer/Modifier2.java
+++ b/renderer/src/main/java/armyc2/c5isr/JavaTacticalRenderer/Modifier2.java
@@ -602,6 +602,9 @@ public class Modifier2 {
                 case TacticalLines.TURNING_MOVEMENT:
                     label = "T";
                     break;
+                case TacticalLines.INFILTRATION:
+                    label = "IN";
+                    break;
                 default:
                     break;
             }
@@ -2171,6 +2174,7 @@ public class Modifier2 {
                 case TacticalLines.AAAAA:
                 case TacticalLines.MAIN:
                 case TacticalLines.DIRATKSPT:
+                case TacticalLines.INFILTRATION:
                 case TacticalLines.DIRATKGND:
                 case TacticalLines.LAUNCH_AREA:
                 case TacticalLines.DEFENDED_AREA_CIRCULAR:
@@ -2467,6 +2471,9 @@ public class Modifier2 {
                     //midPt=lineutility.MidPointDouble(pt0, midPt, 0);
                     AddIntegralAreaModifier(tg, tg.get_Name(), aboveMiddle, 0, pt0, midPt, false);
                     addDTG(tg, aboveMiddle, csFactor, 2 * csFactor, pt0, pt1, metrics);
+                    break;
+                case TacticalLines.INFILTRATION:
+                    AddIntegralModifier(tg, label, aboveMiddle, 0, middleSegment, middleSegment + 1, true);
                     break;
                 case TacticalLines.SPT:
                 case TacticalLines.FRONTAL_ATTACK:

--- a/renderer/src/main/java/armyc2/c5isr/JavaTacticalRenderer/Modifier2.java
+++ b/renderer/src/main/java/armyc2/c5isr/JavaTacticalRenderer/Modifier2.java
@@ -261,6 +261,9 @@ public class Modifier2 {
                 case TacticalLines.RIP:
                     label = "RIP";
                     break;
+                case TacticalLines.DEMONSTRATE:
+                    label = "DEM";
+                    break;
                 case TacticalLines.WITHDRAW:
                     label = "W";
                     break;
@@ -2123,6 +2126,7 @@ public class Modifier2 {
                 case TacticalLines.TORPEDO:
                 case TacticalLines.OPTICAL:
                 case TacticalLines.RIP:
+                case TacticalLines.DEMONSTRATE:
                 case TacticalLines.BOMB:
                 case TacticalLines.ZONE:
                 case TacticalLines.AT:
@@ -3160,6 +3164,7 @@ public class Modifier2 {
                 case TacticalLines.WDRAWUP:
                 case TacticalLines.FPOL:
                 case TacticalLines.RPOL:
+                case TacticalLines.DEMONSTRATE:
                     AddIntegralModifier(tg, label, aboveMiddle, 0, 0, 1, true);
                     break;
                 case TacticalLines.RIP:

--- a/renderer/src/main/java/armyc2/c5isr/JavaTacticalRenderer/clsChannelUtility.java
+++ b/renderer/src/main/java/armyc2/c5isr/JavaTacticalRenderer/clsChannelUtility.java
@@ -133,6 +133,7 @@ public final class clsChannelUtility {
                 case TacticalLines.SPT:
                 case TacticalLines.FRONTAL_ATTACK:
                 case TacticalLines.TURNING_MOVEMENT:
+                case TacticalLines.MOVEMENT_TO_CONTACT:
                     if (fromSegment == 0) {
                         lineType2 = TacticalLines.CHANNEL_FLARED;
                     } else {
@@ -162,6 +163,7 @@ public final class clsChannelUtility {
                         case TacticalLines.SPT:
                         case TacticalLines.FRONTAL_ATTACK:
                         case TacticalLines.TURNING_MOVEMENT:
+                        case TacticalLines.MOVEMENT_TO_CONTACT:
                             lineType2 = TacticalLines.SPT_STRAIGHT;
                             break;
                         case TacticalLines.MAIN:
@@ -472,6 +474,7 @@ public final class clsChannelUtility {
                 case TacticalLines.SPT:
                 case TacticalLines.FRONTAL_ATTACK:
                 case TacticalLines.TURNING_MOVEMENT:
+                case TacticalLines.MOVEMENT_TO_CONTACT:
                     clsUtility.ReorderPixels(pixels);
                     numPoints = pixels.length / 2;
 

--- a/renderer/src/main/java/armyc2/c5isr/JavaTacticalRenderer/clsChannelUtility.java
+++ b/renderer/src/main/java/armyc2/c5isr/JavaTacticalRenderer/clsChannelUtility.java
@@ -132,6 +132,7 @@ public final class clsChannelUtility {
                     break;
                 case TacticalLines.SPT:
                 case TacticalLines.FRONTAL_ATTACK:
+                case TacticalLines.TURNING_MOVEMENT:
                     if (fromSegment == 0) {
                         lineType2 = TacticalLines.CHANNEL_FLARED;
                     } else {
@@ -160,6 +161,7 @@ public final class clsChannelUtility {
                     switch (lineType) {
                         case TacticalLines.SPT:
                         case TacticalLines.FRONTAL_ATTACK:
+                        case TacticalLines.TURNING_MOVEMENT:
                             lineType2 = TacticalLines.SPT_STRAIGHT;
                             break;
                         case TacticalLines.MAIN:
@@ -469,6 +471,7 @@ public final class clsChannelUtility {
                 case TacticalLines.AAAAA:
                 case TacticalLines.SPT:
                 case TacticalLines.FRONTAL_ATTACK:
+                case TacticalLines.TURNING_MOVEMENT:
                     clsUtility.ReorderPixels(pixels);
                     numPoints = pixels.length / 2;
 

--- a/renderer/src/main/java/armyc2/c5isr/JavaTacticalRenderer/clsChannelUtility.java
+++ b/renderer/src/main/java/armyc2/c5isr/JavaTacticalRenderer/clsChannelUtility.java
@@ -131,6 +131,7 @@ public final class clsChannelUtility {
                     lineType2 = lineType;
                     break;
                 case TacticalLines.SPT:
+                case TacticalLines.FRONTAL_ATTACK:
                     if (fromSegment == 0) {
                         lineType2 = TacticalLines.CHANNEL_FLARED;
                     } else {
@@ -158,6 +159,7 @@ public final class clsChannelUtility {
                 if (fromSegment != 0) {
                     switch (lineType) {
                         case TacticalLines.SPT:
+                        case TacticalLines.FRONTAL_ATTACK:
                             lineType2 = TacticalLines.SPT_STRAIGHT;
                             break;
                         case TacticalLines.MAIN:
@@ -466,6 +468,7 @@ public final class clsChannelUtility {
                 case TacticalLines.AIRAOA:
                 case TacticalLines.AAAAA:
                 case TacticalLines.SPT:
+                case TacticalLines.FRONTAL_ATTACK:
                     clsUtility.ReorderPixels(pixels);
                     numPoints = pixels.length / 2;
 

--- a/renderer/src/main/java/armyc2/c5isr/JavaTacticalRenderer/clsUtility.java
+++ b/renderer/src/main/java/armyc2/c5isr/JavaTacticalRenderer/clsUtility.java
@@ -178,6 +178,7 @@ public final class clsUtility {
                 break;
             case TacticalLines.SPTBYFIRE:
             case TacticalLines.RIP:
+            case TacticalLines.MOBILE_DEFENSE:
             case TacticalLines.DEMONSTRATE:
             case TacticalLines.GAP:
             case TacticalLines.ASLTXING:
@@ -653,6 +654,7 @@ public final class clsUtility {
                 case TacticalLines.EASY:
                 case TacticalLines.BYDIF:
                 case TacticalLines.BYIMP:
+                case TacticalLines.MOBILE_DEFENSE:
                     tg.set_lineCap(BasicStroke.CAP_BUTT);
                     if (shape.getShapeType() == Shape2.SHAPE_TYPE_FILL) {
                         shape.set_Fillstyle(1 /*GraphicProperties.FILL_TYPE_SOLID*/);
@@ -806,6 +808,7 @@ public final class clsUtility {
                 case TacticalLines.RETAIN:
                 case TacticalLines.SECURE:
                 case TacticalLines.AREA_DEFENSE:
+                case TacticalLines.MOBILE_DEFENSE:
                 case TacticalLines.FLOT:
                 case TacticalLines.LC:
                 case TacticalLines.PL:

--- a/renderer/src/main/java/armyc2/c5isr/JavaTacticalRenderer/clsUtility.java
+++ b/renderer/src/main/java/armyc2/c5isr/JavaTacticalRenderer/clsUtility.java
@@ -721,6 +721,22 @@ public final class clsUtility {
                         }
                     }
                     break;
+                case TacticalLines.MOVEMENT_TO_CONTACT:
+                    if (shape.getShapeType() == Shape2.SHAPE_TYPE_FILL) {
+                        shape.set_Fillstyle(tg.get_FillStyle());
+                        shape.setFillColor(tg.get_FillColor());
+                        // If there are 4 points and the first and last are the same this is
+                        // an arrow at the end of a jaggy line and should be filled with line color
+                        POINT2 firstPt = shape.getPoints().get(0);
+                        POINT2 lastPt = shape.getPoints().get(shape.getPoints().size() - 1);
+                        if (shape.getPoints().size() == 4 && firstPt.x == lastPt.x && firstPt.y == lastPt.y)
+                            shape.setFillColor(tg.get_LineColor());
+                    }
+                    if (shape.getShapeType() == Shape2.SHAPE_TYPE_POLYLINE) {
+                        shape.setLineColor(tg.get_LineColor());
+                        shape.set_Style(lineStyle);
+                    }
+                    break;
                 default:
                     if (shape.getShapeType() == Shape2.SHAPE_TYPE_FILL) {
                         shape.set_Fillstyle(tg.get_FillStyle());
@@ -1045,6 +1061,7 @@ public final class clsUtility {
                     case TacticalLines.SPT:
                     case TacticalLines.FRONTAL_ATTACK:
                     case TacticalLines.TURNING_MOVEMENT:
+                    case TacticalLines.MOVEMENT_TO_CONTACT:
                     case TacticalLines.MAIN:
                     case TacticalLines.CATKBYFIRE:	//80
                         ArrayList<Shape2> tempShapes=new ArrayList();
@@ -1496,6 +1513,7 @@ public final class clsUtility {
                 case TacticalLines.SPT:
                 case TacticalLines.FRONTAL_ATTACK:
                 case TacticalLines.TURNING_MOVEMENT:
+                case TacticalLines.MOVEMENT_TO_CONTACT:
                 case TacticalLines.LC:
                 case TacticalLines.UNSP:
                 case TacticalLines.DFENCE:

--- a/renderer/src/main/java/armyc2/c5isr/JavaTacticalRenderer/clsUtility.java
+++ b/renderer/src/main/java/armyc2/c5isr/JavaTacticalRenderer/clsUtility.java
@@ -1044,6 +1044,7 @@ public final class clsUtility {
                     case TacticalLines.AAAAA:
                     case TacticalLines.SPT:
                     case TacticalLines.FRONTAL_ATTACK:
+                    case TacticalLines.TURNING_MOVEMENT:
                     case TacticalLines.MAIN:
                     case TacticalLines.CATKBYFIRE:	//80
                         ArrayList<Shape2> tempShapes=new ArrayList();
@@ -1494,6 +1495,7 @@ public final class clsUtility {
                 case TacticalLines.AAAAA:
                 case TacticalLines.SPT:
                 case TacticalLines.FRONTAL_ATTACK:
+                case TacticalLines.TURNING_MOVEMENT:
                 case TacticalLines.LC:
                 case TacticalLines.UNSP:
                 case TacticalLines.DFENCE:

--- a/renderer/src/main/java/armyc2/c5isr/JavaTacticalRenderer/clsUtility.java
+++ b/renderer/src/main/java/armyc2/c5isr/JavaTacticalRenderer/clsUtility.java
@@ -412,6 +412,7 @@ public final class clsUtility {
             case TacticalLines.ENCIRCLE:
             case TacticalLines.DHA_REVD:
             case TacticalLines.DHA:
+            case TacticalLines.KILL_ZONE:
             case TacticalLines.EPW:
             case TacticalLines.RHA:
             case TacticalLines.DSA:

--- a/renderer/src/main/java/armyc2/c5isr/JavaTacticalRenderer/clsUtility.java
+++ b/renderer/src/main/java/armyc2/c5isr/JavaTacticalRenderer/clsUtility.java
@@ -201,6 +201,7 @@ public final class clsUtility {
             case TacticalLines.SEIZE:
             case TacticalLines.EVACUATE:
             case TacticalLines.WITHDRAW:
+            case TacticalLines.DISENGAGE:
             case TacticalLines.WDRAWUP:
             //non task autoshapes
             case TacticalLines.SARA:

--- a/renderer/src/main/java/armyc2/c5isr/JavaTacticalRenderer/clsUtility.java
+++ b/renderer/src/main/java/armyc2/c5isr/JavaTacticalRenderer/clsUtility.java
@@ -696,6 +696,28 @@ public final class clsUtility {
                         }
                     }
                     break;
+                case TacticalLines.AREA_DEFENSE:
+                    if (shape.getShapeType() == Shape2.SHAPE_TYPE_FILL) {
+                        shape.set_Fillstyle(tg.get_FillStyle());
+                        shape.setFillColor(tg.get_FillColor());
+                        // If there are 5 points and the first and last are the same this is
+                        // a triangle and should be filled with line color
+                        POINT2 firstPt = shape.getPoints().get(0);
+                        POINT2 lastPt = shape.getPoints().get(shape.getPoints().size() - 1);
+                        if (shape.getPoints().size() == 5 && firstPt.x == lastPt.x && firstPt.y == lastPt.y) {
+                            shape.set_Fillstyle(1);
+                            shape.setFillColor(tg.get_LineColor());
+                        }
+                    }
+                    if (shape.getShapeType() == Shape2.SHAPE_TYPE_POLYLINE) {
+                        shape.setLineColor(tg.get_LineColor());
+                        shape.set_Style(lineStyle);
+                        if (hasFill || clsUtility.isClosedPolygon(lineType) || clsUtility.IsChange1Area(lineType)) {
+                            shape.set_Fillstyle(tg.get_FillStyle());
+                            shape.setFillColor(tg.get_FillColor());
+                        }
+                    }
+                    break;
                 default:
                     if (shape.getShapeType() == Shape2.SHAPE_TYPE_FILL) {
                         shape.set_Fillstyle(tg.get_FillStyle());
@@ -782,6 +804,7 @@ public final class clsUtility {
                 case TacticalLines.OCCUPY:
                 case TacticalLines.RETAIN:
                 case TacticalLines.SECURE:
+                case TacticalLines.AREA_DEFENSE:
                 case TacticalLines.FLOT:
                 case TacticalLines.LC:
                 case TacticalLines.PL:

--- a/renderer/src/main/java/armyc2/c5isr/JavaTacticalRenderer/clsUtility.java
+++ b/renderer/src/main/java/armyc2/c5isr/JavaTacticalRenderer/clsUtility.java
@@ -737,6 +737,19 @@ public final class clsUtility {
                         shape.set_Style(lineStyle);
                     }
                     break;
+                case TacticalLines.EXPLOIT:
+                    // Some shapes have solid lines some have dashed
+                    if (shape.getShapeType() == Shape2.SHAPE_TYPE_FILL) {
+                        shape.set_Fillstyle(tg.get_FillStyle());
+                        shape.setFillColor(tg.get_FillColor());
+                    }
+                    if (shape.getShapeType() == Shape2.SHAPE_TYPE_POLYLINE) {
+                        shape.setLineColor(tg.get_LineColor());
+                        if (shapeStyle != 1 /*GraphicProperties.LINE_TYPE_DASHED*/) {
+                            shape.set_Style(lineStyle);
+                        }
+                    }
+                    break;
                 default:
                     if (shape.getShapeType() == Shape2.SHAPE_TYPE_FILL) {
                         shape.set_Fillstyle(tg.get_FillStyle());
@@ -1133,7 +1146,7 @@ public final class clsUtility {
                    stroke = getLineStroke(lineThickness, 0, tg.get_lineCap(), BasicStroke.JOIN_ROUND);
                    arrowHeadShape.setStroke(stroke);
                }
-           } else if (tg.get_LineType() == TacticalLines.DIRATKGND || tg.get_LineType() == TacticalLines.DIRATKSPT) {
+           } else if (tg.get_LineType() == TacticalLines.DIRATKGND || tg.get_LineType() == TacticalLines.DIRATKSPT || tg.get_LineType() == TacticalLines.EXPLOIT) {
                 // Make arrowhead shape solid even if tg.get_LineStyle() isn't
                 Shape2 arrowHeadShape = shapes.get(1);
                 arrowHeadShape.set_Style(0);

--- a/renderer/src/main/java/armyc2/c5isr/JavaTacticalRenderer/clsUtility.java
+++ b/renderer/src/main/java/armyc2/c5isr/JavaTacticalRenderer/clsUtility.java
@@ -199,6 +199,7 @@ public final class clsUtility {
             case TacticalLines.COVER:
             case TacticalLines.GUARD:
             case TacticalLines.SEIZE:
+            case TacticalLines.EVACUATE:
             case TacticalLines.WITHDRAW:
             case TacticalLines.WDRAWUP:
             //non task autoshapes

--- a/renderer/src/main/java/armyc2/c5isr/JavaTacticalRenderer/clsUtility.java
+++ b/renderer/src/main/java/armyc2/c5isr/JavaTacticalRenderer/clsUtility.java
@@ -178,6 +178,7 @@ public final class clsUtility {
                 break;
             case TacticalLines.SPTBYFIRE:
             case TacticalLines.RIP:
+            case TacticalLines.DEMONSTRATE:
             case TacticalLines.GAP:
             case TacticalLines.ASLTXING:
             case TacticalLines.MSDZ:

--- a/renderer/src/main/java/armyc2/c5isr/JavaTacticalRenderer/clsUtility.java
+++ b/renderer/src/main/java/armyc2/c5isr/JavaTacticalRenderer/clsUtility.java
@@ -1043,6 +1043,7 @@ public final class clsUtility {
                     case TacticalLines.AIRAOA:
                     case TacticalLines.AAAAA:
                     case TacticalLines.SPT:
+                    case TacticalLines.FRONTAL_ATTACK:
                     case TacticalLines.MAIN:
                     case TacticalLines.CATKBYFIRE:	//80
                         ArrayList<Shape2> tempShapes=new ArrayList();
@@ -1492,6 +1493,7 @@ public final class clsUtility {
                 case TacticalLines.AIRAOA:
                 case TacticalLines.AAAAA:
                 case TacticalLines.SPT:
+                case TacticalLines.FRONTAL_ATTACK:
                 case TacticalLines.LC:
                 case TacticalLines.UNSP:
                 case TacticalLines.DFENCE:

--- a/renderer/src/main/java/armyc2/c5isr/JavaTacticalRenderer/clsUtility.java
+++ b/renderer/src/main/java/armyc2/c5isr/JavaTacticalRenderer/clsUtility.java
@@ -194,6 +194,7 @@ public final class clsUtility {
             case TacticalLines.DISRUPT:
             case TacticalLines.PENETRATE:
             case TacticalLines.RETIRE:
+            case TacticalLines.PURSUIT:
             case TacticalLines.FPOL:
             case TacticalLines.RPOL:
             case TacticalLines.SCREEN:

--- a/renderer/src/main/java/armyc2/c5isr/JavaTacticalRenderer/clsUtility.java
+++ b/renderer/src/main/java/armyc2/c5isr/JavaTacticalRenderer/clsUtility.java
@@ -371,6 +371,7 @@ public final class clsUtility {
             case TacticalLines.MEZ:
             case TacticalLines.LOMEZ:
             case TacticalLines.HIMEZ:
+            case TacticalLines.WFZ_REVD:
             case TacticalLines.WFZ:
             case TacticalLines.PNO:
             case TacticalLines.BATTLE:
@@ -611,6 +612,7 @@ public final class clsUtility {
                 case TacticalLines.NUC:
                 case TacticalLines.CHEM:
                 case TacticalLines.RAD:
+                case TacticalLines.WFZ_REVD:
                 case TacticalLines.WFZ:
                 //case TacticalLines.OBSAREA:
                     fillStyle=3;

--- a/renderer/src/main/java/armyc2/c5isr/JavaTacticalRenderer/clsUtility.java
+++ b/renderer/src/main/java/armyc2/c5isr/JavaTacticalRenderer/clsUtility.java
@@ -195,6 +195,7 @@ public final class clsUtility {
             case TacticalLines.PENETRATE:
             case TacticalLines.RETIRE:
             case TacticalLines.PURSUIT:
+            case TacticalLines.ENVELOPMENT:
             case TacticalLines.FPOL:
             case TacticalLines.RPOL:
             case TacticalLines.SCREEN:

--- a/renderer/src/main/java/armyc2/c5isr/JavaTacticalRenderer/clsUtility.java
+++ b/renderer/src/main/java/armyc2/c5isr/JavaTacticalRenderer/clsUtility.java
@@ -848,6 +848,7 @@ public final class clsUtility {
 //                case TacticalLines.SAAFR:
                 case TacticalLines.DIRATKGND:
                 case TacticalLines.DIRATKSPT:
+                case TacticalLines.INFILTRATION:
                 case TacticalLines.FCL:
                 case TacticalLines.HOLD:
                 case TacticalLines.BRDGHD:
@@ -1146,7 +1147,7 @@ public final class clsUtility {
                    stroke = getLineStroke(lineThickness, 0, tg.get_lineCap(), BasicStroke.JOIN_ROUND);
                    arrowHeadShape.setStroke(stroke);
                }
-           } else if (tg.get_LineType() == TacticalLines.DIRATKGND || tg.get_LineType() == TacticalLines.DIRATKSPT || tg.get_LineType() == TacticalLines.EXPLOIT) {
+           } else if (tg.get_LineType() == TacticalLines.DIRATKGND || tg.get_LineType() == TacticalLines.DIRATKSPT || tg.get_LineType() == TacticalLines.EXPLOIT || lineType == TacticalLines.INFILTRATION) {
                 // Make arrowhead shape solid even if tg.get_LineStyle() isn't
                 Shape2 arrowHeadShape = shapes.get(1);
                 arrowHeadShape.set_Style(0);
@@ -1911,6 +1912,7 @@ public final class clsUtility {
                 case TacticalLines.DIRATKAIR:
                 case TacticalLines.DIRATKGND:
                 case TacticalLines.DIRATKSPT:
+                case TacticalLines.INFILTRATION:
                     // Direction of attack symbols only have two points but can handle more
                     return false;
                 default:

--- a/renderer/src/main/java/armyc2/c5isr/RenderMultipoints/clsClipPolygon2.java
+++ b/renderer/src/main/java/armyc2/c5isr/RenderMultipoints/clsClipPolygon2.java
@@ -652,6 +652,7 @@ public final class clsClipPolygon2 {
                 case TacticalLines.OCCUPY:
                 case TacticalLines.RETAIN:
                 case TacticalLines.ISOLATE:
+                case TacticalLines.AREA_DEFENSE:
                 case TacticalLines.CONVOY:
                 case TacticalLines.HCONVOY:
                     return shapes;

--- a/renderer/src/main/java/armyc2/c5isr/RenderMultipoints/clsClipPolygon2.java
+++ b/renderer/src/main/java/armyc2/c5isr/RenderMultipoints/clsClipPolygon2.java
@@ -641,6 +641,7 @@ public final class clsClipPolygon2 {
             {
                 case TacticalLines.ABATIS:
                 case TacticalLines.SPT:
+                case TacticalLines.FRONTAL_ATTACK:
                 case TacticalLines.MAIN:
                 case TacticalLines.AAAAA:
                 case TacticalLines.AIRAOA:

--- a/renderer/src/main/java/armyc2/c5isr/RenderMultipoints/clsClipPolygon2.java
+++ b/renderer/src/main/java/armyc2/c5isr/RenderMultipoints/clsClipPolygon2.java
@@ -643,6 +643,7 @@ public final class clsClipPolygon2 {
                 case TacticalLines.SPT:
                 case TacticalLines.FRONTAL_ATTACK:
                 case TacticalLines.TURNING_MOVEMENT:
+                case TacticalLines.MOVEMENT_TO_CONTACT:
                 case TacticalLines.MAIN:
                 case TacticalLines.AAAAA:
                 case TacticalLines.AIRAOA:

--- a/renderer/src/main/java/armyc2/c5isr/RenderMultipoints/clsClipPolygon2.java
+++ b/renderer/src/main/java/armyc2/c5isr/RenderMultipoints/clsClipPolygon2.java
@@ -653,6 +653,7 @@ public final class clsClipPolygon2 {
                 case TacticalLines.RETAIN:
                 case TacticalLines.ISOLATE:
                 case TacticalLines.AREA_DEFENSE:
+                case TacticalLines.MOBILE_DEFENSE:
                 case TacticalLines.CONVOY:
                 case TacticalLines.HCONVOY:
                     return shapes;

--- a/renderer/src/main/java/armyc2/c5isr/RenderMultipoints/clsClipPolygon2.java
+++ b/renderer/src/main/java/armyc2/c5isr/RenderMultipoints/clsClipPolygon2.java
@@ -642,6 +642,7 @@ public final class clsClipPolygon2 {
                 case TacticalLines.ABATIS:
                 case TacticalLines.SPT:
                 case TacticalLines.FRONTAL_ATTACK:
+                case TacticalLines.TURNING_MOVEMENT:
                 case TacticalLines.MAIN:
                 case TacticalLines.AAAAA:
                 case TacticalLines.AIRAOA:

--- a/renderer/src/main/java/armyc2/c5isr/RenderMultipoints/clsClipQuad.java
+++ b/renderer/src/main/java/armyc2/c5isr/RenderMultipoints/clsClipQuad.java
@@ -450,6 +450,7 @@ public final class clsClipQuad {
                 case TacticalLines.SPT:
                 case TacticalLines.FRONTAL_ATTACK:
                 case TacticalLines.TURNING_MOVEMENT:
+                case TacticalLines.MOVEMENT_TO_CONTACT:
                 case TacticalLines.MAIN:
                 case TacticalLines.AAAAA:
                 case TacticalLines.AIRAOA:

--- a/renderer/src/main/java/armyc2/c5isr/RenderMultipoints/clsClipQuad.java
+++ b/renderer/src/main/java/armyc2/c5isr/RenderMultipoints/clsClipQuad.java
@@ -448,6 +448,7 @@ public final class clsClipQuad {
             {
                 case TacticalLines.ABATIS:
                 case TacticalLines.SPT:
+                case TacticalLines.FRONTAL_ATTACK:
                 case TacticalLines.MAIN:
                 case TacticalLines.AAAAA:
                 case TacticalLines.AIRAOA:

--- a/renderer/src/main/java/armyc2/c5isr/RenderMultipoints/clsClipQuad.java
+++ b/renderer/src/main/java/armyc2/c5isr/RenderMultipoints/clsClipQuad.java
@@ -460,6 +460,7 @@ public final class clsClipQuad {
                 case TacticalLines.RETAIN:
                 case TacticalLines.ISOLATE:
                 case TacticalLines.AREA_DEFENSE:
+                case TacticalLines.MOBILE_DEFENSE:
                 case TacticalLines.CONVOY:
                 case TacticalLines.HCONVOY:
                     return shapes;

--- a/renderer/src/main/java/armyc2/c5isr/RenderMultipoints/clsClipQuad.java
+++ b/renderer/src/main/java/armyc2/c5isr/RenderMultipoints/clsClipQuad.java
@@ -449,6 +449,7 @@ public final class clsClipQuad {
                 case TacticalLines.ABATIS:
                 case TacticalLines.SPT:
                 case TacticalLines.FRONTAL_ATTACK:
+                case TacticalLines.TURNING_MOVEMENT:
                 case TacticalLines.MAIN:
                 case TacticalLines.AAAAA:
                 case TacticalLines.AIRAOA:

--- a/renderer/src/main/java/armyc2/c5isr/RenderMultipoints/clsClipQuad.java
+++ b/renderer/src/main/java/armyc2/c5isr/RenderMultipoints/clsClipQuad.java
@@ -459,6 +459,7 @@ public final class clsClipQuad {
                 case TacticalLines.OCCUPY:
                 case TacticalLines.RETAIN:
                 case TacticalLines.ISOLATE:
+                case TacticalLines.AREA_DEFENSE:
                 case TacticalLines.CONVOY:
                 case TacticalLines.HCONVOY:
                     return shapes;

--- a/renderer/src/main/java/armyc2/c5isr/RenderMultipoints/clsRenderer.java
+++ b/renderer/src/main/java/armyc2/c5isr/RenderMultipoints/clsRenderer.java
@@ -2021,7 +2021,46 @@ public final class clsRenderer {
 
     public static int getCMLineType(int version, int entityCode) {
         // Check if line type is specific to a version
-        if (version == SymbolID.Version_2525E){
+        if (version >= SymbolID.Version_2525Ech1) {
+            switch (entityCode) {
+                // Added in 2525Ech1
+                case 152600:
+                    return TacticalLines.AREA_DEFENSE;
+                case 152700:
+                    return TacticalLines.FRONTAL_ATTACK;
+                case 152900:
+                    return TacticalLines.TURNING_MOVEMENT;
+                case 152800:
+                    return TacticalLines.MOBILE_DEFENSE;
+                case 242800:
+                    return TacticalLines.KILL_ZONE;
+                case 342900:
+                    return TacticalLines.MOVEMENT_TO_CONTACT;
+                case 343100:
+                    return TacticalLines.EXPLOIT;
+                case 343300:
+                    return TacticalLines.DEMONSTRATE;
+                case 343500:
+                    return TacticalLines.ENVELOPMENT;
+                case 343800:
+                    return TacticalLines.INFILTRATION;
+                case 344000:
+                    return TacticalLines.PURSUIT;
+                case 344400:
+                    return TacticalLines.DISENGAGE;
+                case 344500:
+                    return TacticalLines.EVACUATE;
+                // Removed in 2525Ech1
+                case 240804:
+                    return -1;
+                // Code changed in 2525Ech1
+                case 270504:
+                    return -1; // TacticalLines.TURN in older versions
+                case 344700:
+                    return TacticalLines.TURN;
+            }
+        }
+        if (version >= SymbolID.Version_2525E) {
             switch (entityCode) {
                 // Added in 2525E
                 case 110400:
@@ -2069,7 +2108,7 @@ public final class clsRenderer {
                     return TacticalLines.BCL_REVD;
                 case 310100:
                     return TacticalLines.DHA_REVD;
-                    // Removed in 2525E
+                // Removed in 2525E
                 case 150300:
                     return TacticalLines.ASSY;
                 case 241601:

--- a/renderer/src/main/java/armyc2/c5isr/RenderMultipoints/clsRenderer.java
+++ b/renderer/src/main/java/armyc2/c5isr/RenderMultipoints/clsRenderer.java
@@ -1077,6 +1077,7 @@ public final class clsRenderer {
                     case TacticalLines.MAIN:
                     case TacticalLines.SPT:
                     case TacticalLines.FRONTAL_ATTACK:
+                    case TacticalLines.TURNING_MOVEMENT:
                         POINT2 ptPixels = armyc2.c5isr.JavaTacticalRenderer.clsUtility.ComputeLastPoint(tg.Pixels);
                         tg.Pixels.add(ptPixels);
                         //Point pt = clsUtility.POINT2ToPoint(ptPixels);

--- a/renderer/src/main/java/armyc2/c5isr/RenderMultipoints/clsRenderer.java
+++ b/renderer/src/main/java/armyc2/c5isr/RenderMultipoints/clsRenderer.java
@@ -1311,7 +1311,7 @@ public final class clsRenderer {
                 POINT2 ptB = new POINT2(points.get(4));
                 POINT2 ptC = new POINT2(points.get(9));
                 shapes.add(DISMSupport.getFDIShape(tg, ptA, ptB, ptC));
-            } else if (lineType == TacticalLines.DIRATKSPT) {
+            } else if (lineType == TacticalLines.DIRATKSPT || lineType == TacticalLines.INFILTRATION) {
                 ArrayList<POINT2> points = shapes.get(1).getPoints();
                 POINT2 ptA = new POINT2(points.get(0));
                 POINT2 ptB = new POINT2(points.get(1));

--- a/renderer/src/main/java/armyc2/c5isr/RenderMultipoints/clsRenderer.java
+++ b/renderer/src/main/java/armyc2/c5isr/RenderMultipoints/clsRenderer.java
@@ -728,6 +728,7 @@ public final class clsRenderer {
                 case TacticalLines.ACA:
                 case TacticalLines.ACA_RECTANGULAR:
                 case TacticalLines.ACA_CIRCULAR:
+                case TacticalLines.WFZ:
                     ArrayList<Double> X = milStd.getModifiers_AM_AN_X(Modifiers.X_ALTITUDE_DEPTH);
                     if (X != null && X.size() > 0) {
                         strXAlt = createAltitudeLabel(X.get(0), altitudeUnit, altitudeLabel);
@@ -2061,6 +2062,9 @@ public final class clsRenderer {
                     return TacticalLines.DISENGAGE;
                 case 344500:
                     return TacticalLines.EVACUATE;
+                // Updated in 2525Ech1
+                case 172000:
+                    return TacticalLines.WFZ;
                 // Removed in 2525Ech1
                 case 240804:
                     return -1;
@@ -2105,6 +2109,9 @@ public final class clsRenderer {
                     return TacticalLines.BCL;
                 case 310100:
                     return TacticalLines.DHA;
+                // Updated in 2525Ech1
+                case 172000:
+                    return TacticalLines.WFZ_REVD;
             }
         } else { // 2525Dchange 1 and older
             switch (entityCode) {
@@ -2128,6 +2135,9 @@ public final class clsRenderer {
                     return TacticalLines.SENSOR_RECTANGULAR;
                 case 241603:
                     return TacticalLines.SENSOR_CIRCULAR;
+                // Updated in 2525Ech1
+                case 172000:
+                    return TacticalLines.WFZ_REVD;
             }
         }
         // Line type isn't specific to a version or doesn't exist
@@ -2284,8 +2294,6 @@ public final class clsRenderer {
                 return TacticalLines.HIMEZ;
             case 171900:
                 return TacticalLines.FAADZ;
-            case 172000:
-                return TacticalLines.WFZ;
             case 200401:
                 return TacticalLines.SHIP_AOI_CIRCULAR;
             case 240804:

--- a/renderer/src/main/java/armyc2/c5isr/RenderMultipoints/clsRenderer.java
+++ b/renderer/src/main/java/armyc2/c5isr/RenderMultipoints/clsRenderer.java
@@ -1078,6 +1078,7 @@ public final class clsRenderer {
                     case TacticalLines.SPT:
                     case TacticalLines.FRONTAL_ATTACK:
                     case TacticalLines.TURNING_MOVEMENT:
+                    case TacticalLines.MOVEMENT_TO_CONTACT:
                         POINT2 ptPixels = armyc2.c5isr.JavaTacticalRenderer.clsUtility.ComputeLastPoint(tg.Pixels);
                         tg.Pixels.add(ptPixels);
                         //Point pt = clsUtility.POINT2ToPoint(ptPixels);

--- a/renderer/src/main/java/armyc2/c5isr/RenderMultipoints/clsRenderer.java
+++ b/renderer/src/main/java/armyc2/c5isr/RenderMultipoints/clsRenderer.java
@@ -1317,7 +1317,15 @@ public final class clsRenderer {
                 POINT2 ptB = new POINT2(points.get(1));
                 POINT2 ptC = new POINT2(points.get(2));
                 shapes.add(DISMSupport.getFDIShape(tg, ptA, ptB, ptC));
-            } else {
+            }
+            else if (lineType == TacticalLines.EXPLOIT) {
+                ArrayList<POINT2> points = shapes.get(1).getPoints();
+                POINT2 ptA = new POINT2(points.get(0));
+                POINT2 ptB = new POINT2(points.get(1));
+                POINT2 ptC = new POINT2(points.get(2));
+                shapes.add(DISMSupport.getFDIShape(tg, ptA, ptB, ptC));
+            }
+            else {
                 // Shape has no arrow. Put on top of shape
                 POINT2 firstPoint = shapes.get(0).getPoints().get(0);
                 POINT2 ptUl = new POINT2(firstPoint);

--- a/renderer/src/main/java/armyc2/c5isr/RenderMultipoints/clsRenderer.java
+++ b/renderer/src/main/java/armyc2/c5isr/RenderMultipoints/clsRenderer.java
@@ -1076,6 +1076,7 @@ public final class clsRenderer {
                     case TacticalLines.AIRAOA:
                     case TacticalLines.MAIN:
                     case TacticalLines.SPT:
+                    case TacticalLines.FRONTAL_ATTACK:
                         POINT2 ptPixels = armyc2.c5isr.JavaTacticalRenderer.clsUtility.ComputeLastPoint(tg.Pixels);
                         tg.Pixels.add(ptPixels);
                         //Point pt = clsUtility.POINT2ToPoint(ptPixels);

--- a/renderer/src/main/java/armyc2/c5isr/RenderMultipoints/clsUtility.java
+++ b/renderer/src/main/java/armyc2/c5isr/RenderMultipoints/clsUtility.java
@@ -744,6 +744,7 @@ public final class clsUtility {
                 case TacticalLines.SPT:
                 case TacticalLines.FRONTAL_ATTACK:
                 case TacticalLines.TURNING_MOVEMENT:
+                case TacticalLines.MOVEMENT_TO_CONTACT:
                 case TacticalLines.MAIN:
                     break;
                 default:
@@ -904,6 +905,7 @@ public final class clsUtility {
                 case TacticalLines.SPT:
                 case TacticalLines.FRONTAL_ATTACK:
                 case TacticalLines.TURNING_MOVEMENT:
+                case TacticalLines.MOVEMENT_TO_CONTACT:
                 case TacticalLines.MAIN:
                 case TacticalLines.CATKBYFIRE:	//80
                     return;

--- a/renderer/src/main/java/armyc2/c5isr/RenderMultipoints/clsUtility.java
+++ b/renderer/src/main/java/armyc2/c5isr/RenderMultipoints/clsUtility.java
@@ -501,6 +501,7 @@ public final class clsUtility {
             case TacticalLines.FPOL:
             case TacticalLines.RPOL:
             case TacticalLines.RIP:
+            case TacticalLines.MOBILE_DEFENSE:
             case TacticalLines.DEMONSTRATE:
             case TacticalLines.DELAY:
             case TacticalLines.CATK:

--- a/renderer/src/main/java/armyc2/c5isr/RenderMultipoints/clsUtility.java
+++ b/renderer/src/main/java/armyc2/c5isr/RenderMultipoints/clsUtility.java
@@ -743,6 +743,7 @@ public final class clsUtility {
                 case TacticalLines.AAAAA:
                 case TacticalLines.SPT:
                 case TacticalLines.FRONTAL_ATTACK:
+                case TacticalLines.TURNING_MOVEMENT:
                 case TacticalLines.MAIN:
                     break;
                 default:
@@ -902,6 +903,7 @@ public final class clsUtility {
                 case TacticalLines.AAAAA:
                 case TacticalLines.SPT:
                 case TacticalLines.FRONTAL_ATTACK:
+                case TacticalLines.TURNING_MOVEMENT:
                 case TacticalLines.MAIN:
                 case TacticalLines.CATKBYFIRE:	//80
                     return;

--- a/renderer/src/main/java/armyc2/c5isr/RenderMultipoints/clsUtility.java
+++ b/renderer/src/main/java/armyc2/c5isr/RenderMultipoints/clsUtility.java
@@ -742,6 +742,7 @@ public final class clsUtility {
                 case TacticalLines.AIRAOA:
                 case TacticalLines.AAAAA:
                 case TacticalLines.SPT:
+                case TacticalLines.FRONTAL_ATTACK:
                 case TacticalLines.MAIN:
                     break;
                 default:
@@ -900,6 +901,7 @@ public final class clsUtility {
                 case TacticalLines.AIRAOA:
                 case TacticalLines.AAAAA:
                 case TacticalLines.SPT:
+                case TacticalLines.FRONTAL_ATTACK:
                 case TacticalLines.MAIN:
                 case TacticalLines.CATKBYFIRE:	//80
                     return;

--- a/renderer/src/main/java/armyc2/c5isr/RenderMultipoints/clsUtility.java
+++ b/renderer/src/main/java/armyc2/c5isr/RenderMultipoints/clsUtility.java
@@ -496,6 +496,7 @@ public final class clsUtility {
             case TacticalLines.BOUNDARY:
             case TacticalLines.WDRAWUP:
             case TacticalLines.WITHDRAW:
+            case TacticalLines.DISENGAGE:
             case TacticalLines.RETIRE:
             case TacticalLines.FPOL:
             case TacticalLines.RPOL:

--- a/renderer/src/main/java/armyc2/c5isr/RenderMultipoints/clsUtility.java
+++ b/renderer/src/main/java/armyc2/c5isr/RenderMultipoints/clsUtility.java
@@ -501,6 +501,7 @@ public final class clsUtility {
             case TacticalLines.FPOL:
             case TacticalLines.RPOL:
             case TacticalLines.RIP:
+            case TacticalLines.DEMONSTRATE:
             case TacticalLines.DELAY:
             case TacticalLines.CATK:
             case TacticalLines.CATKBYFIRE:

--- a/renderer/src/main/java/armyc2/c5isr/RenderMultipoints/clsUtility.java
+++ b/renderer/src/main/java/armyc2/c5isr/RenderMultipoints/clsUtility.java
@@ -96,6 +96,7 @@ public final class clsUtility {
                     hatchColor = Color.yellow;
                     hatchLineThickness = 3 + (tg.get_LineThickness() - 3) * (float) tg.get_patternScale();
                     break;
+                case TacticalLines.WFZ_REVD:
                 case TacticalLines.WFZ:
                     hatchStyle=Hatch_BackwardDiagonal;
                     if (tg.get_LineColor() == Color.BLACK)

--- a/renderer/src/main/java/armyc2/c5isr/RenderMultipoints/clsUtilityCPOF.java
+++ b/renderer/src/main/java/armyc2/c5isr/RenderMultipoints/clsUtilityCPOF.java
@@ -1442,6 +1442,7 @@ public final class clsUtilityCPOF {
                 case TacticalLines.ROUTE_ALT:
                 case TacticalLines.DHA_REVD:
                 case TacticalLines.DHA:
+                case TacticalLines.KILL_ZONE:
                 case TacticalLines.EPW:
                 case TacticalLines.FARP:
                 case TacticalLines.RHA:

--- a/renderer/src/main/java/armyc2/c5isr/RenderMultipoints/clsUtilityCPOF.java
+++ b/renderer/src/main/java/armyc2/c5isr/RenderMultipoints/clsUtilityCPOF.java
@@ -1956,6 +1956,7 @@ public final class clsUtilityCPOF {
                 case TacticalLines.SPT:
                 case TacticalLines.FRONTAL_ATTACK:
                 case TacticalLines.TURNING_MOVEMENT:
+                case TacticalLines.MOVEMENT_TO_CONTACT:
                 case TacticalLines.AIRAOA:
                 case TacticalLines.AAAAA:
                     return false;

--- a/renderer/src/main/java/armyc2/c5isr/RenderMultipoints/clsUtilityCPOF.java
+++ b/renderer/src/main/java/armyc2/c5isr/RenderMultipoints/clsUtilityCPOF.java
@@ -1954,6 +1954,7 @@ public final class clsUtilityCPOF {
                 case TacticalLines.CATKBYFIRE:
                 case TacticalLines.MAIN:
                 case TacticalLines.SPT:
+                case TacticalLines.FRONTAL_ATTACK:
                 case TacticalLines.AIRAOA:
                 case TacticalLines.AAAAA:
                     return false;

--- a/renderer/src/main/java/armyc2/c5isr/RenderMultipoints/clsUtilityCPOF.java
+++ b/renderer/src/main/java/armyc2/c5isr/RenderMultipoints/clsUtilityCPOF.java
@@ -1338,6 +1338,7 @@ public final class clsUtilityCPOF {
                 case TacticalLines.DIRATKAIR:
                 case TacticalLines.DIRATKGND:
                 case TacticalLines.DIRATKSPT:
+                case TacticalLines.INFILTRATION:
                 case TacticalLines.FCL:
                 case TacticalLines.HOLD:
                 case TacticalLines.BRDGHD:
@@ -1509,6 +1510,7 @@ public final class clsUtilityCPOF {
             case TacticalLines.DIRATKAIR:
             case TacticalLines.DIRATKGND:
             case TacticalLines.DIRATKSPT:
+            case TacticalLines.INFILTRATION:
             case TacticalLines.FCL:
             case TacticalLines.HOLD:
             case TacticalLines.BRDGHD:

--- a/renderer/src/main/java/armyc2/c5isr/RenderMultipoints/clsUtilityCPOF.java
+++ b/renderer/src/main/java/armyc2/c5isr/RenderMultipoints/clsUtilityCPOF.java
@@ -1331,6 +1331,7 @@ public final class clsUtilityCPOF {
                 case TacticalLines.MEZ:
                 case TacticalLines.LOMEZ:
                 case TacticalLines.HIMEZ:
+                case TacticalLines.WFZ_REVD:
                 case TacticalLines.WFZ:
                 case TacticalLines.AIRFIELD:
                 case TacticalLines.BATTLE:

--- a/renderer/src/main/java/armyc2/c5isr/RenderMultipoints/clsUtilityCPOF.java
+++ b/renderer/src/main/java/armyc2/c5isr/RenderMultipoints/clsUtilityCPOF.java
@@ -1955,6 +1955,7 @@ public final class clsUtilityCPOF {
                 case TacticalLines.MAIN:
                 case TacticalLines.SPT:
                 case TacticalLines.FRONTAL_ATTACK:
+                case TacticalLines.TURNING_MOVEMENT:
                 case TacticalLines.AIRAOA:
                 case TacticalLines.AAAAA:
                     return false;

--- a/renderer/src/main/java/armyc2/c5isr/RenderMultipoints/clsUtilityGE.java
+++ b/renderer/src/main/java/armyc2/c5isr/RenderMultipoints/clsUtilityGE.java
@@ -325,6 +325,7 @@ public final class clsUtilityGE {
                 case TacticalLines.MAIN:
                 case TacticalLines.SPT:
                 case TacticalLines.FRONTAL_ATTACK:
+                case TacticalLines.TURNING_MOVEMENT:
                 
                 case TacticalLines.SARA:
                 case TacticalLines.RANGE_FAN_SECTOR:

--- a/renderer/src/main/java/armyc2/c5isr/RenderMultipoints/clsUtilityGE.java
+++ b/renderer/src/main/java/armyc2/c5isr/RenderMultipoints/clsUtilityGE.java
@@ -324,6 +324,7 @@ public final class clsUtilityGE {
                 case TacticalLines.AAAAA:
                 case TacticalLines.MAIN:
                 case TacticalLines.SPT:
+                case TacticalLines.FRONTAL_ATTACK:
                 
                 case TacticalLines.SARA:
                 case TacticalLines.RANGE_FAN_SECTOR:

--- a/renderer/src/main/java/armyc2/c5isr/RenderMultipoints/clsUtilityGE.java
+++ b/renderer/src/main/java/armyc2/c5isr/RenderMultipoints/clsUtilityGE.java
@@ -326,6 +326,7 @@ public final class clsUtilityGE {
                 case TacticalLines.SPT:
                 case TacticalLines.FRONTAL_ATTACK:
                 case TacticalLines.TURNING_MOVEMENT:
+                case TacticalLines.MOVEMENT_TO_CONTACT:
                 
                 case TacticalLines.SARA:
                 case TacticalLines.RANGE_FAN_SECTOR:

--- a/renderer/src/main/java/armyc2/c5isr/renderer/symbolpicker/TreeManager.java
+++ b/renderer/src/main/java/armyc2/c5isr/renderer/symbolpicker/TreeManager.java
@@ -29,7 +29,6 @@ public class TreeManager {
             "25343700", // Exfiltrate
             "25343800", // Infiltrate
             "25343900", // Locate
-            "25344000", // Pursue
             "25350000", // Space debris
             "25350100", "25350101", "25350102", "25350103", // Man made space debris
             "25350200", "25350201", "25350202", "25350203", // Natural space debris

--- a/renderer/src/main/java/armyc2/c5isr/renderer/symbolpicker/TreeManager.java
+++ b/renderer/src/main/java/armyc2/c5isr/renderer/symbolpicker/TreeManager.java
@@ -67,7 +67,7 @@ public class TreeManager {
         String symbolSet = "";
 
         InputStream is;
-        if (version == SymbolID.Version_2525E) {
+        if (version >= SymbolID.Version_2525E) {
             is = context.getResources().openRawResource(R.raw.mse);
         } else {
             is = context.getResources().openRawResource(R.raw.msd);

--- a/renderer/src/main/java/armyc2/c5isr/renderer/utilities/DrawRules.java
+++ b/renderer/src/main/java/armyc2/c5isr/renderer/utilities/DrawRules.java
@@ -405,6 +405,21 @@ public class DrawRules {
      */
     public static final int AREA26 = 126;
 
+    /**
+     * Anchor Points: This symbol requires three anchor points. Point 1 defines
+     * the tip of the arrowhead. Point 2 defines the end of the straight-line
+     * portion of the symbol. Point 3 defines the diameter and orientation of
+     * the 180 degree circular arc.
+     *
+     * Size/Shape: Points 1 and 2 determine the length of the straight-line
+     * portion of the symbol. Point 3 defines which side of the line the arc
+     * is on and the diameter of the arc
+     *
+     * Orientation: Determined by the anchor points.
+     *
+     * Used by: Ech1
+     */
+    public static final int AREA27 = 127;
 
     /**
      * Anchor Points: This symbol requires one anchor point. The anchor point

--- a/renderer/src/main/java/armyc2/c5isr/renderer/utilities/MSInfo.java
+++ b/renderer/src/main/java/armyc2/c5isr/renderer/utilities/MSInfo.java
@@ -235,6 +235,9 @@ public class MSInfo {
             case "area26":
                 idr = DrawRules.AREA26;
                 break;
+            case "area27":
+                idr = DrawRules.AREA27;
+                break;
             case "point1":
                 idr = DrawRules.POINT1;
                 break;
@@ -372,6 +375,18 @@ public class MSInfo {
                 break;
             case "line29":
                 idr = DrawRules.LINE29;
+                break;
+            case "line30":
+                idr = DrawRules.LINE30;
+                break;
+            case "line31":
+                idr = DrawRules.LINE31;
+                break;
+            case "line32":
+                idr = DrawRules.LINE32;
+                break;
+            case "line33":
+                idr = DrawRules.LINE33;
                 break;
             case "corridor1":
                 idr = DrawRules.CORRIDOR1;
@@ -529,6 +544,7 @@ public class MSInfo {
             case DrawRules.AREA21:
             case DrawRules.AREA24:
             case DrawRules.AREA25:
+            case DrawRules.AREA27:
             case DrawRules.POINT12:
             case DrawRules.LINE3:
             case DrawRules.LINE6://doesn't seem to be used
@@ -539,6 +555,9 @@ public class MSInfo {
             case DrawRules.LINE23:
             case DrawRules.LINE24:
             case DrawRules.LINE29://Ambush
+            case DrawRules.LINE30:
+            case DrawRules.LINE32:
+            case DrawRules.LINE33:
             case DrawRules.POLYLINE1:
                 points[0] = 3;
                 points[1] = 3;
@@ -566,6 +585,7 @@ public class MSInfo {
             case DrawRules.AREA18:
             case DrawRules.LINE11:
             case DrawRules.LINE16:
+            case DrawRules.LINE31:
                 points[0] = 4;
                 points[1] = 4;
                 break;

--- a/renderer/src/main/java/armyc2/c5isr/renderer/utilities/MSLookup.java
+++ b/renderer/src/main/java/armyc2/c5isr/renderer/utilities/MSLookup.java
@@ -86,7 +86,7 @@ public class MSLookup {
 
         try
         {
-            if(version == SymbolID.Version_2525E) {
+            if(version >= SymbolID.Version_2525E) {
                 lookup = _MSLookupE;
                 list = _IDListE;
             }
@@ -709,7 +709,7 @@ public class MSLookup {
         int length = basicID.length();
         if(length == 8)
         {
-            if(version == SymbolID.Version_2525E)
+            if(version >= SymbolID.Version_2525E)
                 return _MSLookupE.getOrDefault(basicID, null);
             else if (version == SymbolID.Version_2525D && basicID.equals("25272100"))
                 // MSDZ can have extra point in D
@@ -735,7 +735,7 @@ public class MSLookup {
     {
         if(version < SymbolID.Version_2525E)
             return _IDListD;
-        else if(version == SymbolID.Version_2525E)
+        else if(version >= SymbolID.Version_2525E)
             return _IDListE;
         else
             return _IDListD;
@@ -763,7 +763,7 @@ public class MSLookup {
                 else
                     ErrorLogger.LogMessage("Symbol Set and Entity Code combination already exist: " + msInfo.getBasicSymbolID(), Level.INFO,false);
             }
-            else if (version == SymbolID.Version_2525E)
+            else if (version >= SymbolID.Version_2525E)
             {
                 if(this._IDListE.indexOf(msInfo.getBasicSymbolID()) == -1)
                 {

--- a/renderer/src/main/java/armyc2/c5isr/renderer/utilities/SVGLookup.java
+++ b/renderer/src/main/java/armyc2/c5isr/renderer/utilities/SVGLookup.java
@@ -72,7 +72,7 @@ public class SVGLookup {
     private void loadData(InputStream is, int version)
     {
         Map<String, SVGInfo> lookup;
-        if(version == SymbolID.Version_2525E)
+        if(version >= SymbolID.Version_2525E)
             lookup = _SVGLookupE;
         else
             lookup = _SVGLookupD;
@@ -604,7 +604,7 @@ public class SVGLookup {
                     SVGLookup._SVGLookupD.put(svgInfo.getID(),svgInfo);
                 }
             }
-            else if (version == SymbolID.Version_2525E)
+            else if (version >= SymbolID.Version_2525E)
             {
                 if(SVGLookup._SVGLookupE.containsKey(svgInfo.getID()) == false)
                 {

--- a/renderer/src/main/java/armyc2/c5isr/web/render/MultiPointHandler.java
+++ b/renderer/src/main/java/armyc2/c5isr/web/render/MultiPointHandler.java
@@ -755,7 +755,9 @@ public class MultiPointHandler {
 
                 //moving meta data properties to the last feature with no coords as feature collection doesn't allow properties
                 jsonOutput.replace(jsonOutput.toString().length()-1,jsonOutput.toString().length(),"" );
-                jsonOutput.append(",{\"type\": \"Feature\",\"geometry\": { \"type\": \"Polygon\",\"coordinates\": [ ]}");
+                if (jsonContent.length() > 2)
+                    jsonOutput.append(",");
+                jsonOutput.append("{\"type\": \"Feature\",\"geometry\": { \"type\": \"Polygon\",\"coordinates\": [ ]}");
 
                 jsonOutput.append(",\"properties\":{\"id\":\"");
                 jsonOutput.append(id);
@@ -1316,7 +1318,9 @@ public class MultiPointHandler {
 
                 //moving meta data properties to the last feature with no coords as feature collection doesn't allow properties
                 jsonOutput.replace(jsonOutput.toString().length()-1,jsonOutput.toString().length(),"" );
-                jsonOutput.append(",{\"type\": \"Feature\",\"geometry\": { \"type\": \"Polygon\",\"coordinates\": [ ]}");
+                if (jsonContent.length() > 2)
+                    jsonOutput.append(",");
+                jsonOutput.append("{\"type\": \"Feature\",\"geometry\": { \"type\": \"Polygon\",\"coordinates\": [ ]}");
 
                 jsonOutput.append(",\"properties\":{\"id\":\"");
                 jsonOutput.append(id);
@@ -2295,9 +2299,9 @@ public class MultiPointHandler {
             String shapesToAdd = ShapeToGeoJSONString(shapes.get(i), ipc, normalize);
             if (shapesToAdd.length() > 0) {
                 fc.append(shapesToAdd);
-            }
-            if (i < len - 1) {
-                fc.append(",");
+                if (i < len - 1) {
+                    fc.append(",");
+                }
             }
         }
 
@@ -2313,7 +2317,8 @@ public class MultiPointHandler {
                 modifiersToAdd = LabelToGeoJSONString(tempModifier, ipc, normalize, textColor, textBackgroundColor);
             }
             if (modifiersToAdd.length() > 0) {
-                fc.append(",");
+                if (fc.length() > 1)
+                    fc.append(",");
                 fc.append(modifiersToAdd);
             }
         }
@@ -3555,7 +3560,9 @@ public class MultiPointHandler {
 
                 //moving meta data properties to the last feature with no coords as feature collection doesn't allow properties
                 jsonOutput.replace(jsonOutput.toString().length()-1,jsonOutput.toString().length(),"" );
-                jsonOutput.append(",{\"type\": \"Feature\",\"geometry\": { \"type\": \"Polygon\",\"coordinates\": [ ]}");
+                if (jsonContent.length() > 2)
+                    jsonOutput.append(",");
+                jsonOutput.append("{\"type\": \"Feature\",\"geometry\": { \"type\": \"Polygon\",\"coordinates\": [ ]}");
 
                 jsonOutput.append(",\"properties\":{\"id\":\"");
                 jsonOutput.append(id);

--- a/renderer/src/main/java/armyc2/c5isr/web/render/MultiPointHandler.java
+++ b/renderer/src/main/java/armyc2/c5isr/web/render/MultiPointHandler.java
@@ -2899,8 +2899,8 @@ public class MultiPointHandler {
             MSInfo info = MSLookup.getInstance().getMSLInfo(symbolID);
 
             if (info == null) {
-                if (SymbolID.getVersion(symbolID) == SymbolID.Version_2525E) {
-                    return"Basic ID: " + basicID + " not recognized in version E (13)";
+                if (SymbolID.getVersion(symbolID) >= SymbolID.Version_2525E) {
+                    return"Basic ID: " + basicID + " not recognized in version E (15)";
                 } else {
                     return "Basic ID: " + basicID + " not recognized in version D (11)";
                 }

--- a/renderer/src/main/res/raw/mse.txt
+++ b/renderer/src/main/res/raw/mse.txt
@@ -50,6 +50,8 @@
 		Bomb		130100
 		Decoy		130200
 	Manual Track			140000
+	Equipment			150000
+		Tactical Air Navigation (TACAN)		150100
 02	Unspecified			0
 	Missile			110000
 05	Unspecified			0
@@ -134,11 +136,13 @@
 			Motorized 	121104
 			Infantry Fighting Vehicle	121105
 			Main Gun System	121106
+			Marine Air Ground Task Force (MAGTF)	121107
 		Observer		121200
 		Reconnaissance/Cavalry/Scout		121300
 			Reconnaissance and Surveillance	121301
 			Marine	121302
 			Motorized	121303
+			Reconnaissance Artillery, Mounted Operation	121304
 		Sea Air Land (SEAL)		121400
 		Sniper		121500
 		Surveillance		121600
@@ -149,6 +153,7 @@
 			Underwater Demolition	121805
 		Unmanned Aerial Systems		121900
 		Ranger		122000
+		Combined Combat Unit		122100
 	Fires			130000
 		Air Defense		130100
 			Main Gun System	130101
@@ -156,6 +161,7 @@
 			Air and Missile Defense	130103
 		Air/Land Naval Gunfire Liaison		130200
 		Field Artillery		130300
+			Reconnaissance (FIST)	130303
 		Field Artillery Observer		130400
 		Joint Fire Support		130500
 		Meteorological		130600
@@ -204,8 +210,6 @@
 			Analysis	150501
 			Direction Finding	150502
 			Intercept	150503
-			Jamming	150504
-			Search	150505
 		Intercept (Search and Recording)		150600
 		Interrogation		150700
 		Jamming		150800
@@ -259,6 +263,7 @@
 		Contracting Services		165400
 		Parachute Rigger		165500
 		Human Resources		165600
+		Field Feeding		165700
 	Naval 			170000
 		Naval		170100
 	Named Headquarters			180000
@@ -476,6 +481,7 @@
 			Military	201302
 		Unit Deployment Shipments		201400
 		Emergency Medical Operation		201500
+		Tactical Air Navigation (TACAN)		201600
 	Land Mines			210000
 		Land Mine		210100
 		Antipersonnel Land mine (APL)		210200
@@ -512,8 +518,8 @@
 		Safe House		111700
 		White List Location		111800
 		Tented Camp		111900
-			Displaced Persons/ Refugee/Evacuees Camp	111901
-			Training Camp	111902
+			Civilian Camp	111903
+			Military Camp	111904
 		Warehouse/Storage Facility		112000
 			Grenade	112001
 		Law Enforcement		112100
@@ -533,6 +539,7 @@
 			Fire Station	112201
 			Emergency Medical Operation	112202
 		Home/House		112300
+		Non-Governmental Organization		112400
 	Infrastructure			120000
 		Agriculture and Food Infrastructure		120100
 			Agriculture Laboratory	120101
@@ -697,9 +704,9 @@
 		Pick-Up Zone		150900	Area	Area1	T	
 		Fortified Area		151000	Area	Area1	T	
 		Limited Access Area		151100	Area	Area2		
-		Battle Position		151200	Area	Area3	B,T	
-			Prepared (P) but not Occupied	151202	Area	Area3	B,T	
-			Strong Point	151203	Area	Area4	B,T	
+		Battle Position		151200	Area	Area1	B,T	
+			Prepared (P) but not Occupied	151202	Area	Area1	B,T	
+			Strong Point	151203	Area	Area1	B,T	
 			Contain	151204	Area	Area5		
 			Retain	151205	Area	Area6		
 		Engagement Area (EA)		151300	Area	Area1	T	
@@ -707,7 +714,7 @@
 			Friendly Airborne/Aviation	151401	Line	Axis1	T,W,W1	
 			Attack Helicopter	151402	Line	Axis1	T,W,W1	
 			Main Attack	151403	Line	Axis2	T,W,W1	
-			Supporting Attack	151404	Line	Axis2	T,W,W1	
+			Supporting Attack	151404	Line	Axis1	T,W,W1	
 		Assault Position		151500	Area	Area1	T	
 		Attack Position		151600	Area	Area1	T	
 		Objective		151700	Area	Area1	T	
@@ -716,6 +723,10 @@
 		Attack by Fire Position		152000	Area	Area7		
 		Support by Fire		152100	Area	Area8		
 		Search Area/Reconnaissance Area		152200	Area	Area21		
+		Area Defense		152600	Area	Area15		
+		Frontal Attack		152700	Line	Axis1	T,W,W1	
+		Mobile Defense		152800	Area	Area27		
+		Turning Movement		152900	Line	Axis1	T,W,W1	
 	Maneuver Points			160000				
 		Observation Post/Outpost (unspecified)		160100	Point	Point2		
 		Observation Post/Outpost (specified)		160200	Point			
@@ -784,7 +795,7 @@
 			Ellipse/Circle	200201	Area	Ellipse1	AM,AN,T
 			Rectangle	200202	Area	Rectangular1	AM,T	
 		No Attack (NOTACK) Zone		200300	Area	Circular1	AM,W,W1	
-		Ship Area of Interest		200400	Point	Point3		
+		Ship Area of Interest		200400	Point	Point2		
 			Ellipse/Circle	200401	Area	Ellipse1	AM,AN
 			Rectangle	200402	Area	Rectangular1	AM
 		Active Maneuver Area		200500	Point	Point2		
@@ -820,31 +831,31 @@
 		Formation		212700	Point	Point2		
 		Harbor		212800	Point	Point8	H	
 		Harbor Entrance Point		212900				
-			A	212901	Point	Point8		
-			Q	212902	Point	Point8		
-			X	212903	Point	Point8		
-			Y	212904	Point	Point8		
+			A	212901	Point	Point2		
+			Q	212902	Point	Point2		
+			X	212903	Point	Point2		
+			Y	212904	Point	Point2		
 		Dip Position		213000	Point	Point2		
 		Search		213100	Point	Point2		
 		Search Area		213200	Point	Point2		
 		Search Center		213300	Point	Point2		
 		Navigational Reference Point		213400	Point	Point2		
-		Sonobuoy		213500	Point	Point10	T,H	
-			Ambient Noise	213501	Point	Point10	T,H	
-			Air Transportable Communication	213502	Point	Point10	H	
-			Barra	213503	Point	Point10	H	
-			Bathythermograph Transmitting	213504	Point	Point10	T,H	
-			Command Active Multi-Beam (CAMBS)	213505	Point	Point10	H	
-			Command Active Sonobuoy Directional Command Active Sonobuoy System (CASS)	213506	Point	Point10	H	
-			Directional Frequency Analysis and Recording (DIFAR)	213507	Point	Point10	T,H	
-			Directional Command Active Sonobuoy System (DICASS)	213508	Point	Point10	T,H	
-			Expendable Reliable Acoustic Path Sonobuoy (ERAPS)	213509	Point	Point10	H	
-			Expired	213510	Point	Point10		
-			Kingpin	213511	Point	Point10	H	
-			Low Frequency Analysis and Recording (LOFAR)	213512	Point	Point10	H	
-			Pattern Center	213513	Point	Point10	H	
-			Range Only	213514	Point	Point10	H	
-			Vertical Line Array Directional Frequency Analysis and Recording (DIFAR)	213515	Point	Point10	T,H	
+		Sonobuoy		213500	Point	Point2	T,H	
+			Ambient Noise	213501	Point	Point2	T,H	
+			Air Transportable Communication	213502	Point	Point2	H	
+			Barra	213503	Point	Point2	H	
+			Bathythermograph Transmitting	213504	Point	Point2	T,H	
+			Command Active Multi-Beam (CAMBS)	213505	Point	Point2	H	
+			Command Active Sonobuoy Directional Command Active Sonobuoy System (CASS)	213506	Point	Point2	H	
+			Directional Frequency Analysis and Recording (DIFAR)	213507	Point	Point2	T,H	
+			Directional Command Active Sonobuoy System (DICASS)	213508	Point	Point2	T,H	
+			Expendable Reliable Acoustic Path Sonobuoy (ERAPS)	213509	Point	Point2	H	
+			Expired	213510	Point	Point2		
+			Kingpin	213511	Point	Point2	H	
+			Low Frequency Analysis and Recording (LOFAR)	213512	Point	Point2	H	
+			Pattern Center	213513	Point	Point2	H	
+			Range Only	213514	Point	Point2	H	
+			Vertical Line Array Directional Frequency Analysis and Recording (DIFAR)	213515	Point	Point2	T,H	
 		Reference Point		213600	Point	Point2		
 		Special Point		213700	Point	Point2		
 		Navigational Reference Point(Points)		213800	Point	Point2		
@@ -902,20 +913,20 @@
 			Bottom Return/Non-MILCO, Wreck, Dangerous	219100	Point	Point2		
 			Bottom Return/Non-MILCO, Wreck, Non Dangerous	219200	Point	Point2		
 	Maritime Control Lines			220000				
-		Bearing Line		220100	Line	Line5	H	
-			Electronic	220101	Line	Line5	H	
-			Electronic Warfare (EW)	220102	Line	Line5	H	
-			Acoustic	220103	Line	Line5	H	
-			Acoustic (Ambiguous)	220104	Line	Line5	H	
-			Torpedo	220105	Line	Line5	H	
-			Electro-Optical Intercept	220106	Line	Line5	H	
-			Jammer	220107	Line	Line5	H	
-			Radio Direction Finder (RDF)	220108	Line	Line5	H	
+		Bearing Line		220100	Line	Line1	H	
+			Electronic	220101	Line	Line1	H	
+			Electronic Warfare (EW)	220102	Line	Line1	H	
+			Acoustic	220103	Line	Line1	H	
+			Acoustic (Ambiguous)	220104	Line	Line1	H	
+			Torpedo	220105	Line	Line1	H	
+			Electro-Optical Intercept	220106	Line	Line1	H	
+			Jammer	220107	Line	Line1	H	
+			Radio Direction Finder (RDF)	220108	Line	Line1	H	
 	Fires Areas			240000				
 		Airspace Coordination Area		240100				
 			Irregular	240101	Area	Area1	T,T1,X,Y,W,W1	
-			Rectangular	240102	Area	Rectangular1	AM,T,T1,X,H,W,W1
-			Circular	240103	Area	Circular1	AM,T,T1,X,H,W,W1	
+			Rectangular	240102	Area	Rectangular1	AM,T,T1,X,Y,W,W1
+			Circular	240103	Area	Circular1	AM,T,T1,X,Y,W,W1	
 		Free Fire Area		240200				
 			Irregular	240201	Area	Area1	T,W,W1	
 			Rectangular	240202	Area	Rectangular1	AM,T,W,W1	
@@ -944,8 +955,7 @@
 			Area Target	240801	Area	Area1	AP	
 			Rectangular Target	240802	Area	Rectangular2	AM,AN,AP	
 			Circular Target	240803	Area	Circular1	AM,AP	
-			Rectangular Target - Single Target	240804	Area	Rectangular3	AM,T	
-			Series or Groups of Targets	240805	Area	Area9	T	
+			Series or Groups of Targets	240805	Area	Area1	T	
 			Smoke	240806	Area	Area1	AP,W,W1	
 			Bomb Area	240808	Area	Area1		
 		Fire Support Station		240900	Point	Point2	T	
@@ -995,6 +1005,7 @@
 			Irregular, Purple	242304	Area	Area10	T,W,W1	
 			Rectangular, Purple	242305	Area	Rectangular1	AM,T,W,W1	
 			Circular, Purple	242306	Area	Circular1	AM,T,W,W1	
+		Kill Zone		242800	Area	Area1	T	
 	Fires Points			250000				
 		Firing Point		250100	Point	Point1	H,T,W,W1	
 		Hide Point		250200	Point	Point1	H,T,W,W1	
@@ -1018,7 +1029,6 @@
 			Block	270501	Area	Area11		
 			Disrupt	270502	Area	Area12		
 			Fix	270503	Line	Line9		
-			Turn	270504	Line	Line10		
 		Obstacle Bypass		270600				
 			Easy	270601	Line	Point12		
 			Difficult	270602	Line	Point12		
@@ -1178,15 +1188,15 @@
 		Bypass		340300	Line	Point12		
 		Canalize		340400	Line	Point12		
 		Clear		340500	Line	Line23		
-		Counterattack		340600	Line	Axis2		
-		Counterattack by Fire		340700	Line	Axis2		
+		Counterattack		340600	Line	Axis1		
+		Counterattack by Fire		340700	Line	Axis1		
 		Delay		340800	Line	Line24	W	
 		Destroy		340900	Point	Point2		
 		Disrupt		341000	Area	Area12		
 		Fix		341100	Line	Line9		
 		Follow and Assume		341200	Line	Line25	T	
 		Follow and Support		341300	Line	Line25	T	
-		Interdict		341400	Point	Point14		
+		Interdict		341400	Point	Point2		
 		Isolate		341500	Area	Area15		
 		Neutralize		341600	Point	Point2		
 		Occupy		341700	Area	Area16		
@@ -1204,29 +1214,18 @@
 		Cordon and Knock		342600	Area	Area15		
 		Cordon and Search		342700	Area	Area15		
 		Suppress		342800	Point	Point2		
+		Movement to Contact		342900	Line	Axis1	T,W,W1	
+		Exploit/Exploitation		343100	Line	Line30		
+		Demonstrate/Demonstration		343300	Area	Area18		
+		Envelopment		343500	Line	Line31		
+		Infiltration		343800	Line	Line32		
+		Pursuit		344000	Line	Line33		
 		Forward Passage of Lines		344100	Line	Line24		
 		Rearward Passage of Lines		344200	Line	Line24		
-		Advance to Contact		342900	Line			MISSING
-		Capture		343000	Line			MISSING
-		Conduct Exploitation		343100	Line			MISSING
-		Control		343200	Area			MISSING
-		Demonstration		343300	Line			MISSING
-		Deny		343400	Area			MISSING
-		Envelop		343500	Line			MISSING
-		Escort		343600	Line			MISSING
-		Exfiltrate		343700	Line			MISSING
-		Infiltrate		343800	Line			MISSING
-		Locate		343900	Area			MISSING
-		Pursue		344000	Line			MISSING
-	Space Debris			350000	Point			MISSING
-		Man Made Space Debris		350100				MISSING
-			Man Made Space Debris Small	350101				MISSING
-			Man Made Space Debris Medium	350102				MISSING
-			Man Made Space Debris Big	350103				MISSING
-		Natural Space Debris		350200				MISSING
-			Natural Space Debris Small	350201				MISSING
-			Natural Space Debris Medium	350202				MISSING
-			Natural Space Debris Big	350203				MISSING
+		Defeat		344300	Point	Point2			
+		Disengage		344400	Line	Line24			
+		Evacuate/Evacuation		344500	Line	Line27			
+		Turn		344700	Line	Line10			
 27	Military			110000
 		Activity/Task		110200
 			Explosive Ordnance Disposal	110201
@@ -1313,6 +1312,7 @@
 			Navy Task Unit	121004
 			Convoy	121005
 		Sea-Based X-Band Radar		121100
+		Tactical Air Navigation (TACAN)		121200
 	Military Non Combatant			130000
 		Auxiliary Ship		130100
 			Ammunition Ship	130101
@@ -1393,7 +1393,6 @@
 		Sea Mine, Floating		110300
 		Sea Mine, Rising		110400
 		Sea Mine, Other Position		110500
-		Kingfisher		110600
 		Small Object, Mine-Like		110700
 		Exercise Mine, General		110800
 			Exercise Mine, Bottom	110801
@@ -1486,7 +1485,6 @@
 			Sniping	110401
 		Illegal Drug Operation		110500
 			Trafficking	110501
-			Illegal Drug Lab	110502
 		Explosion		110600
 			Grenade Explosion	110601
 			Incendiary Explosion	110602
@@ -2040,8 +2038,6 @@
 	Threat			150000
 		Malware		150100
 		Phishing		150200
-		Spear Phishing		150300
-		Whale Phishing		150400
 	Data			160000
 		Digital Currency		160100
 		Persona		160200

--- a/renderer/src/main/res/raw/mse.txt
+++ b/renderer/src/main/res/raw/mse.txt
@@ -757,7 +757,7 @@
 		Low Altitude Missile Engagement Zone		171700	Area	Area1	T,X,W,W1	2 X values
 		High Altitude Missile Engagement Zone		171800	Area	Area1	T,X,W,W1	2 X values
 		Short Range Air Defense Engagement Zone		171900	Area	Area1	T,X,W,W1	2 X values
-		Weapons Free Zone		172000	Area	Area1	T,W,W1	
+		Weapons Free Zone		172000	Area	Area1	T,X,W,W1	
 	Airspace Control Points			180000		
 		Air Control Point		180100	Point	Point2	T	
 		Communications Checkpoint		180200	Point	Point2	T	

--- a/renderer/src/main/res/raw/mse.txt
+++ b/renderer/src/main/res/raw/mse.txt
@@ -1218,7 +1218,7 @@
 		Exploit/Exploitation		343100	Line	Line30		
 		Demonstrate/Demonstration		343300	Area	Area18		
 		Envelopment		343500	Line	Line31		
-		Infiltration		343800	Line	Line32		
+		Infiltration		343800	Line	Line1		
 		Pursuit		344000	Line	Line33		
 		Forward Passage of Lines		344100	Line	Line24		
 		Rearward Passage of Lines		344200	Line	Line24		


### PR DESCRIPTION
### Added
- Area Defense
- Frontal attack 
- Mobile defense - pt3 is just used as a vertical distance, it will always be placed directly above pt2
- Turning movement
- Kill Zone
- Movement to contact - added dummy modifier as if axis of advance
- Exploit - pt3 is just used as a distance, it will be placed the same distance away at a 45 degree angle from pt2. Added dummy modifier as if direction of attack
- Demonstrate - Does not force arc to be perpendicular to the line like in line24 and line33
- Envelopment - pt3 is placed onto line pt1 to pt2. pt4 is just used to determine if arc is above or below line
- Infiltration - redesigned as a line1 with an arrow on the last segment and "IN" on the middle segment
- Pursuit
- Disengage
- Evacuate

### Updated
- Airspace coordination (irregular, rectangular and circular in Dch1 and Ech1) - Now defaults to Y modifier, and uses H when Y isn't provided. Removed colon after "EFF" and made "GRID" singular and uppercase  
- Turn

### Removed 
- Rectangular Target

### Other port updates
- https://github.com/missioncommand/mil-sym-java/tree/mp-e-change-one
- https://github.com/missioncommand/mil-sym-ts/tree/mp-e-change-one